### PR TITLE
Layered read views: baseline + additions − removals

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ is netstandard2.0 / net8.0 and builds cross-platform.
 
 ```bash
 dotnet build Semiodesk.Trinity.sln -c Release          # whole solution, SDK-only
-dotnet test Trinity.Tests/Trinity.Tests.csproj         # 413 passed, 7 skipped (quarantined)
+dotnet test Trinity.Tests/Trinity.Tests.csproj         # 542 passed, 7 skipped (quarantined)
 dotnet test tests/Trinity.Generator.Tests/Trinity.Generator.Tests.csproj   # 23 passed
 dotnet test tests/Trinity.Vocabulary.Tests/Trinity.Vocabulary.Tests.csproj # 29 passed
 dotnet pack Trinity/Trinity.csproj -c Release          # -> Semiodesk.Trinity.2.0.0.nupkg
@@ -69,7 +69,7 @@ dotnet pack Trinity/Trinity.csproj -c Release          # -> Semiodesk.Trinity.2.
 - Store integration tests (`tests/Trinity.Tests.*`) **self-provision** their server in Docker via
   Testcontainers on a random host port (ADR-0036): run `dotnet test tests/Trinity.Tests.{Virtuoso,GraphDB,Fuseki}`
   with a Docker daemon running. Excluded from the default CI job (Docker + large images). Current:
-  Virtuoso 103/108 and GraphDB 110/115 pass; Fuseki is 4/86 — a pre-existing dotNetRDF `FusekiConnector`
+  Virtuoso 175/180 and GraphDB 182/187 pass; Fuseki is 4/86 — a pre-existing dotNetRDF `FusekiConnector`
   query-endpoint bug (POSTs `/ds/query`, which the server 404s), unrelated to the container wiring.
   Virtuoso's `Int16Test`/`Uint16Test`/`UintTest` are now `Assert.Inconclusive` in `VirtuosoResourceTest`,
   alongside the pre-existing `Int64Test`/`Uint64Test` overrides for the same phenomenon: Virtuoso widens
@@ -168,6 +168,23 @@ Invariants that surprise newcomers:
   `GetValue`/`SetValue` + `GetTypes()`, now emitted by the source generator (ADR-0013). A
   `[RdfProperty]` on a non-`partial` member is not generated (and no longer woven) — it does nothing.
 - **Models are named graphs; a `ModelGroup` is itself an `IModel`** spanning several (0019).
+- **A `ModelGroup` can only union; subtraction is a separate abstraction** (0041): `ILayeredModel`
+  (`store.CreateLayeredModel(baseline, additions, removals)`) reads `(baseline − removals) ∪ additions`
+  with git-working-tree semantics — additions win on overlap, the baseline stays untouched. It is read-only,
+  and it is deliberately **not** an `IModelGroup`. The mapped reads and LINQ honour the overlay natively; caller-supplied
+  SPARQL is rewritten by `OverlayQueryRewriter` (whitelist over the dotNetRDF parse tree — property paths, `GRAPH`
+  blocks, `SERVICE`, `CONSTRUCT`/`DESCRIBE`, `FILTER EXISTS` and a caller `FROM` are **refused**), and
+  `inferenceEnabled: true` throws. Nothing silently returns unsubtracted triples. **dotNetRDF cannot serialize a
+  negated comparison faithfully** (`!(?r < 3)` → `!?r < 3`, which still parses), so `SparqlExpressionWriter` writes
+  `FILTER`/`BIND` expressions instead; `HAVING` and projected expressions come from dotNetRDF and are only checked,
+  so a negation there is refused. Every rewrite is re-parsed and compared structurally against the original.
+  Caller queries are parsed on **every** execution — see ADR-0041 for the placeholder-IRI caching optimisation
+  if that ever shows up in a profile. The SPARQL is
+  built only by `LayeredModelSparql`, whose emission rules (MINUS vs FILTER NOT EXISTS, `VALUES` before the
+  overlay, selective patterns before the wildcard) are correctness/perf requirements — see the ADR before touching them.
+  **All three graphs must be in the same store** — the overlay is one query over one dataset, so a cross-store view
+  is refused at construction (it used to fail silently in both directions); create views only via
+  `store.CreateLayeredModel`, never by constructing `LayeredModel` directly.
 - **Discovery is global static state** (0020): consumers must `MappingDiscovery.RegisterAssembly`
   / `OntologyDiscovery.AddAssembly` at startup or mapping and SPARQL prefixes silently miss.
 - **No configuration subsystem** (0011, 2.0): the `ontologies.config`/`app.config` loading,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ is netstandard2.0 / net8.0 and builds cross-platform.
 
 ```bash
 dotnet build Semiodesk.Trinity.sln -c Release          # whole solution, SDK-only
-dotnet test Trinity.Tests/Trinity.Tests.csproj         # 542 passed, 7 skipped (quarantined)
+dotnet test Trinity.Tests/Trinity.Tests.csproj         # 589 passed, 7 skipped (quarantined)
 dotnet test tests/Trinity.Generator.Tests/Trinity.Generator.Tests.csproj   # 23 passed
 dotnet test tests/Trinity.Vocabulary.Tests/Trinity.Vocabulary.Tests.csproj # 29 passed
 dotnet pack Trinity/Trinity.csproj -c Release          # -> Semiodesk.Trinity.2.0.0.nupkg
@@ -69,7 +69,7 @@ dotnet pack Trinity/Trinity.csproj -c Release          # -> Semiodesk.Trinity.2.
 - Store integration tests (`tests/Trinity.Tests.*`) **self-provision** their server in Docker via
   Testcontainers on a random host port (ADR-0036): run `dotnet test tests/Trinity.Tests.{Virtuoso,GraphDB,Fuseki}`
   with a Docker daemon running. Excluded from the default CI job (Docker + large images). Current:
-  Virtuoso 175/180 and GraphDB 182/187 pass; Fuseki is 4/86 — a pre-existing dotNetRDF `FusekiConnector`
+  Virtuoso 221/226 and GraphDB 228/233 pass; Fuseki is 4/86 — a pre-existing dotNetRDF `FusekiConnector`
   query-endpoint bug (POSTs `/ds/query`, which the server 404s), unrelated to the container wiring.
   Virtuoso's `Int16Test`/`Uint16Test`/`UintTest` are now `Assert.Inconclusive` in `VirtuosoResourceTest`,
   alongside the pre-existing `Int64Test`/`Uint64Test` overrides for the same phenomenon: Virtuoso widens
@@ -176,8 +176,11 @@ Invariants that surprise newcomers:
   blocks, `SERVICE`, `CONSTRUCT`/`DESCRIBE`, `FILTER EXISTS` and a caller `FROM` are **refused**), and
   `inferenceEnabled: true` throws. Nothing silently returns unsubtracted triples. **dotNetRDF cannot serialize a
   negated comparison faithfully** (`!(?r < 3)` → `!?r < 3`, which still parses), so `SparqlExpressionWriter` writes
-  `FILTER`/`BIND` expressions instead; `HAVING` and projected expressions come from dotNetRDF and are only checked,
-  so a negation there is refused. Every rewrite is re-parsed and compared structurally against the original.
+  `FILTER`/`BIND` expressions instead; `HAVING`, projections, `GROUP BY` and `ORDER BY` come from dotNetRDF and are
+  only checked, so a negation there is refused. Every rewrite is re-parsed and compared structurally against the
+  original. The overlay's two branches are **disjoint by construction** — `UNION` is a bag union, so overlapping
+  branches would duplicate a re-added triple. Blank nodes (incl. `[ … ]`) are refused: the overlay repeats each
+  pattern across three BGPs and SPARQL forbids a label spanning them.
   Caller queries are parsed on **every** execution — see ADR-0041 for the placeholder-IRI caching optimisation
   if that ever shows up in a profile. The SPARQL is
   built only by `LayeredModelSparql`, whose emission rules (MINUS vs FILTER NOT EXISTS, `VALUES` before the

--- a/Trinity.Tests/LayeredModelSparqlTest.cs
+++ b/Trinity.Tests/LayeredModelSparqlTest.cs
@@ -73,13 +73,38 @@ namespace Semiodesk.Trinity.Tests
         /// A pattern with a variable is subtracted with <c>MINUS</c>, which engines evaluate as an
         /// anti-join rather than a per-row probe.
         /// </summary>
+        /// <remarks>
+        /// The overlay also carries a <c>FILTER NOT EXISTS</c> that keeps the two branches disjoint,
+        /// so the assertion is about which primitive guards the <b>baseline</b> branch - the part
+        /// before the <c>UNION</c>.
+        /// </remarks>
         [Test]
         public void OverlayUsesMinusWhenThePatternBindsAVariable()
         {
             string overlay = LayeredModelSparql.Overlay(_view, "?s", "?p", "?o");
+            string baselineBranch = overlay.Substring(0, overlay.IndexOf("UNION", StringComparison.Ordinal));
 
-            Assert.IsTrue(overlay.Contains("MINUS"), overlay);
-            Assert.IsFalse(overlay.Contains("NOT EXISTS"), overlay);
+            Assert.IsTrue(baselineBranch.Contains("MINUS"), overlay);
+            Assert.IsFalse(baselineBranch.Contains("NOT EXISTS"), overlay);
+        }
+
+        /// <summary>
+        /// The two branches must be disjoint, or the bag semantics of <c>UNION</c> duplicate a triple
+        /// that is in both the baseline and the additions.
+        /// </summary>
+        [Test]
+        public void OverlayBranchesAreDisjoint()
+        {
+            string overlay = LayeredModelSparql.Overlay(_view, "?s", "?p", "?o");
+            string additionsBranch = overlay.Substring(overlay.IndexOf("UNION", StringComparison.Ordinal));
+
+            Assert.IsTrue(additionsBranch.Contains(AddGraph.ToString()),
+                "the branch after UNION is the additions branch");
+            Assert.IsTrue(additionsBranch.Contains("FILTER NOT EXISTS"),
+                "the additions branch must exclude what the baseline branch already yielded, or the " +
+                "two overlap and UNION duplicates the solution:\n" + overlay);
+            Assert.IsTrue(additionsBranch.Contains(BaseGraph.ToString()),
+                "that exclusion is expressed against the baseline graph:\n" + overlay);
         }
 
         /// <summary>
@@ -133,21 +158,28 @@ namespace Semiodesk.Trinity.Tests
         #region Overlay structure
 
         /// <summary>
-        /// The guard applies only to the baseline branch, which is what makes additions win.
+        /// The removals guard applies only to the baseline branch, which is what makes additions win.
         /// </summary>
         [Test]
         public void OverlayGuardsOnlyTheBaselineBranch()
         {
             string overlay = LayeredModelSparql.Overlay(_view, "?s", "?p", "?o");
 
-            int baseline = overlay.IndexOf(BaseGraph.ToString(), StringComparison.Ordinal);
-            int guard = overlay.IndexOf("MINUS", StringComparison.Ordinal);
             int union = overlay.IndexOf("UNION", StringComparison.Ordinal);
-            int additions = overlay.IndexOf(AddGraph.ToString(), StringComparison.Ordinal);
+            string baselineBranch = overlay.Substring(0, union);
+            string additionsBranch = overlay.Substring(union);
 
-            Assert.Less(baseline, guard, "the guard must follow the baseline branch");
-            Assert.Less(guard, union, "the guard must sit inside the baseline branch, before the UNION");
-            Assert.Less(union, additions, "the additions branch must follow the UNION, ungarded");
+            Assert.IsTrue(baselineBranch.Contains(BaseGraph.ToString()), overlay);
+            Assert.IsTrue(baselineBranch.Contains(RemGraph.ToString()),
+                "the baseline branch is the one the removals guard applies to");
+
+            // The additions branch references the removals graph only inside its disjointness guard,
+            // never to subtract from itself - subtracting there would stop additions winning.
+            int additionsGraphAt = additionsBranch.IndexOf(AddGraph.ToString(), StringComparison.Ordinal);
+            int notExistsAt = additionsBranch.IndexOf("FILTER NOT EXISTS", StringComparison.Ordinal);
+
+            Assert.Less(additionsGraphAt, notExistsAt,
+                "the additions graph is matched first, then filtered - not guarded before matching");
         }
 
         /// <summary>

--- a/Trinity.Tests/LayeredModelSparqlTest.cs
+++ b/Trinity.Tests/LayeredModelSparqlTest.cs
@@ -1,0 +1,376 @@
+// LICENSE:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// AUTHORS:
+//
+//  Moritz Eberl <moritz@semiodesk.com>
+//  Sebastian Faubel <sebastian@semiodesk.com>
+//
+// Copyright (c) Semiodesk GmbH 2026
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using NUnit.Framework;
+using Semiodesk.Trinity.Query.Sparql;
+
+namespace Semiodesk.Trinity.Tests
+{
+    /// <summary>
+    /// Unit tests for the SPARQL a layered model emits. These need no store: they assert the shape
+    /// of the generated text and the invariants that make it correct, which is where the subtle
+    /// failures live.
+    /// </summary>
+    [TestFixture]
+    public class LayeredModelSparqlTest
+    {
+        #region Members
+
+        private IStore _store;
+
+        private ILayeredModel _view;
+
+        private static readonly Uri BaseGraph = new Uri("http://example.org/g/baseline");
+        private static readonly Uri AddGraph = new Uri("http://example.org/g/additions");
+        private static readonly Uri RemGraph = new Uri("http://example.org/g/removals");
+
+        #endregion
+
+        [SetUp]
+        public void SetUp()
+        {
+            _store = StoreFactory.CreateStore("provider=dotnetrdf");
+            _view = _store.CreateLayeredModel(BaseGraph, AddGraph, RemGraph);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _store.Dispose();
+        }
+
+        #region The guard primitive
+
+        /// <summary>
+        /// A pattern with a variable is subtracted with <c>MINUS</c>, which engines evaluate as an
+        /// anti-join rather than a per-row probe.
+        /// </summary>
+        [Test]
+        public void OverlayUsesMinusWhenThePatternBindsAVariable()
+        {
+            string overlay = LayeredModelSparql.Overlay(_view, "?s", "?p", "?o");
+
+            Assert.IsTrue(overlay.Contains("MINUS"), overlay);
+            Assert.IsFalse(overlay.Contains("NOT EXISTS"), overlay);
+        }
+
+        /// <summary>
+        /// The correctness rule that decides the primitive: SPARQL <c>MINUS</c> removes nothing when
+        /// the two sides share no variables, and a fully ground pattern has none — so there it would
+        /// silently fail to subtract. Ground patterns must use <c>FILTER NOT EXISTS</c>.
+        /// </summary>
+        [Test]
+        public void OverlayUsesNotExistsWhenThePatternIsFullyGround()
+        {
+            string overlay = LayeredModelSparql.Overlay(_view,
+                "<http://example.org/s>", "<http://example.org/p>", "<http://example.org/o>");
+
+            Assert.IsTrue(overlay.Contains("FILTER NOT EXISTS"), overlay);
+            Assert.IsFalse(overlay.Contains("MINUS"), overlay);
+        }
+
+        /// <summary>
+        /// Verifies the trap the previous test guards against is real on this engine, so the rule
+        /// cannot be "simplified" away later: a ground pattern subtracted with MINUS comes back.
+        /// </summary>
+        [Test]
+        public void MinusWouldNotSubtractAGroundPattern()
+        {
+            const string triple = "<http://example.org/s> <http://example.org/p> <http://example.org/o>";
+
+            _store.ExecuteNonQuery(new SparqlUpdate(
+                $"INSERT DATA {{ GRAPH <{BaseGraph}> {{ {triple} . }} GRAPH <{RemGraph}> {{ {triple} . }} }}"));
+
+            Assert.IsFalse(Ask(GuardedWithNotExists(triple)),
+                "FILTER NOT EXISTS must subtract the removed triple");
+
+            Assert.IsTrue(Ask(GuardedWithMinus(triple)),
+                "MINUS must NOT subtract a ground pattern - this is why Overlay() switches primitive. " +
+                "If this assertion ever fails the engine changed and the rule can be revisited.");
+        }
+
+        private static string GuardedWithNotExists(string triple) =>
+            $"ASK FROM NAMED <{BaseGraph}> FROM NAMED <{RemGraph}> {{ GRAPH <{BaseGraph}> {{ {triple} }} " +
+            $"FILTER NOT EXISTS {{ GRAPH <{RemGraph}> {{ {triple} }} }} }}";
+
+        private static string GuardedWithMinus(string triple) =>
+            $"ASK FROM NAMED <{BaseGraph}> FROM NAMED <{RemGraph}> {{ GRAPH <{BaseGraph}> {{ {triple} }} " +
+            $"MINUS {{ GRAPH <{RemGraph}> {{ {triple} }} }} }}";
+
+        private bool Ask(string sparql) =>
+            _store.ExecuteQuery(new SparqlQuery(sparql, declarePrefixes: false)).GetAnwser();
+
+        #endregion
+
+        #region Overlay structure
+
+        /// <summary>
+        /// The guard applies only to the baseline branch, which is what makes additions win.
+        /// </summary>
+        [Test]
+        public void OverlayGuardsOnlyTheBaselineBranch()
+        {
+            string overlay = LayeredModelSparql.Overlay(_view, "?s", "?p", "?o");
+
+            int baseline = overlay.IndexOf(BaseGraph.ToString(), StringComparison.Ordinal);
+            int guard = overlay.IndexOf("MINUS", StringComparison.Ordinal);
+            int union = overlay.IndexOf("UNION", StringComparison.Ordinal);
+            int additions = overlay.IndexOf(AddGraph.ToString(), StringComparison.Ordinal);
+
+            Assert.Less(baseline, guard, "the guard must follow the baseline branch");
+            Assert.Less(guard, union, "the guard must sit inside the baseline branch, before the UNION");
+            Assert.Less(union, additions, "the additions branch must follow the UNION, ungarded");
+        }
+
+        /// <summary>
+        /// The dataset clause names the graphs rather than merging them; FROM would union the
+        /// removals graph straight back in.
+        /// </summary>
+        [Test]
+        public void DatasetClauseNamesAllThreeGraphsAndNeverMergesThem()
+        {
+            string clause = LayeredModelSparql.NamedDatasetClause(_view);
+
+            Assert.AreEqual(3, CountOccurrences(clause, "FROM NAMED"));
+            Assert.IsTrue(clause.Contains($"<{BaseGraph}>"));
+            Assert.IsTrue(clause.Contains($"<{AddGraph}>"));
+            Assert.IsTrue(clause.Contains($"<{RemGraph}>"));
+
+            // No bare FROM: every FROM in the clause must be a FROM NAMED.
+            Assert.AreEqual(3, CountOccurrences(clause, "FROM "));
+        }
+
+        private static int CountOccurrences(string haystack, string needle)
+        {
+            int count = 0, i = 0;
+
+            while ((i = haystack.IndexOf(needle, i, StringComparison.Ordinal)) >= 0)
+            {
+                count++;
+                i += needle.Length;
+            }
+
+            return count;
+        }
+
+        #endregion
+
+        #region ProvidesStatements
+
+        /// <summary>
+        /// Resource materialization refuses any query for which <c>ProvidesStatements()</c> is
+        /// false, and that is decided by a token-level heuristic which wants exactly three
+        /// same-ordered global variables. The overlay adds nesting, UNION and VALUES around the
+        /// triple patterns, so this is easy to break without noticing — every emitted shape is
+        /// asserted here.
+        /// </summary>
+        [TestCaseSource(nameof(EmittedShapes))]
+        public void EveryEmittedShapeProvidesStatements(string label, string sparql)
+        {
+            var query = new SparqlQuery(sparql, declarePrefixes: false);
+
+            Assert.IsTrue(query.ProvidesStatements(),
+                $"{label} must provide statements or GetResources() refuses it outright:\n{sparql}");
+            Assert.AreEqual(new[] { "s", "p", "o" }, query.GetGlobalScopeVariableNames(), label);
+        }
+
+        public static IEnumerable<TestCaseData> EmittedShapes()
+        {
+            var store = StoreFactory.CreateStore("provider=dotnetrdf");
+            var view = store.CreateLayeredModel(BaseGraph, AddGraph, RemGraph);
+
+            string dataset = LayeredModelSparql.NamedDatasetClause(view);
+            string wildcard = LayeredModelSparql.Overlay(view, "?s", "?p", "?o");
+            string typed = LayeredModelSparql.Overlay(view, "?s", "a", "<http://example.org/Thing>");
+            string values = LayeredModelSparql.BindSubjects("?s", new[] { new Uri("http://example.org/r1") });
+
+            yield return new TestCaseData("subject-bound resource read",
+                $"SELECT DISTINCT ?s ?p ?o {dataset}WHERE {{ {values}{wildcard} }}");
+
+            yield return new TestCaseData("multi-subject resource read",
+                "SELECT DISTINCT ?s ?p ?o " + dataset + "WHERE { " +
+                LayeredModelSparql.BindSubjects("?s", new[] { new Uri("http://example.org/r1"), new Uri("http://example.org/r2") }) +
+                wildcard + " }");
+
+            yield return new TestCaseData("type-constrained read",
+                $"SELECT DISTINCT ?s ?p ?o {dataset}WHERE {{ {typed} {wildcard} }}");
+        }
+
+        #endregion
+
+        #region Completeness guard
+
+        /// <summary>
+        /// The one structural defence against the design's dangerous failure mode: a read path added
+        /// to <see cref="LayeredModel"/> later that forgets the overlay and quietly returns
+        /// unsubtracted triples.
+        /// </summary>
+        /// <remarks>
+        /// Every public <see cref="IModel"/> member is either in the honoured list below — and
+        /// covered by an assertion in <c>LayeredModelTest</c> — or it must throw. A new member, or a
+        /// member moved between the two groups, fails this test and forces the decision to be made
+        /// explicitly rather than by omission.
+        /// </remarks>
+        [Test]
+        public void EveryModelMemberIsEitherHonouredOrThrows()
+        {
+            var honoured = new HashSet<string>
+            {
+                // Reads that apply the overlay. Each is asserted in LayeredModelTest.
+                "Uri", "get_Uri",
+                "IsEmpty", "get_IsEmpty",
+                "IgnoreUnmappedProperties", "get_IgnoreUnmappedProperties", "set_IgnoreUnmappedProperties",
+                "ContainsResource",
+                "GetResource",
+                "GetResources",
+                "AsQueryable",
+                // Reads that deliberately refuse a caller query but are not read-only refusals.
+                "ExecuteQuery", "GetBindings",
+            };
+
+            var refused = new HashSet<string>
+            {
+                "AddResource", "CreateResource", "DeleteResource", "DeleteResources",
+                "UpdateResource", "UpdateResources", "ExecuteUpdate", "Clear",
+                "Read", "Write", "BeginTransaction",
+            };
+
+            var unclassified = new List<string>();
+
+            foreach (MemberInfo member in typeof(IModel).GetMembers())
+            {
+                string name = member.Name;
+
+                if (!honoured.Contains(name) && !refused.Contains(name))
+                {
+                    unclassified.Add(name);
+                }
+            }
+
+            Assert.IsEmpty(unclassified,
+                "IModel gained member(s) that a layered model neither honours nor refuses: " +
+                string.Join(", ", unclassified) +
+                ". Decide explicitly: apply the overlay and add a LayeredModelTest assertion, or throw. " +
+                "Leaving it unhandled risks silently returning triples staged for removal.");
+
+            // And prove the refusals really refuse, rather than merely being listed above.
+            var view = _view;
+
+            var alwaysThrows = new List<TestDelegate>
+            {
+                () => view.AddResource(new Resource(new Uri("urn:x"))),
+                () => view.CreateResource(new Uri("urn:x")),
+                () => view.DeleteResource(new Uri("urn:x")),
+                () => view.DeleteResources(new[] { new Uri("urn:x") }),
+                () => view.UpdateResource(new Resource(new Uri("urn:x"))),
+                () => view.UpdateResources(new[] { new Resource(new Uri("urn:x")) }),
+                () => view.ExecuteUpdate(new SparqlUpdate("CLEAR GRAPH <urn:x>")),
+                () => view.Clear(),
+                () => view.Read(new Uri("urn:x"), RdfSerializationFormat.Turtle, false),
+                () => view.Write(new System.IO.MemoryStream(), RdfSerializationFormat.Turtle),
+                () => view.BeginTransaction(System.Data.IsolationLevel.ReadCommitted),
+            };
+
+            foreach (TestDelegate call in alwaysThrows)
+            {
+                Assert.Throws<NotSupportedException>(call);
+            }
+        }
+
+        #endregion
+
+        #region Layer validation
+
+        [Test]
+        public void OverlappingLayersAreRejected()
+        {
+            Assert.Throws<ArgumentException>(() => _store.CreateLayeredModel(BaseGraph, BaseGraph, RemGraph));
+            Assert.Throws<ArgumentException>(() => _store.CreateLayeredModel(BaseGraph, AddGraph, BaseGraph));
+            Assert.Throws<ArgumentException>(() => _store.CreateLayeredModel(BaseGraph, AddGraph, AddGraph));
+        }
+
+        /// <summary>
+        /// A layered model cannot span two stores, and must say so rather than answer from whichever
+        /// graphs the executing store happens to hold.
+        /// </summary>
+        /// <remarks>
+        /// Measured before this guard existed: with the baseline in Virtuoso and the layers in an
+        /// in-memory store, a read returned the triple staged for removal and raised nothing. With the
+        /// stores swapped it silently dropped the baseline instead. Both are exactly the silent wrong
+        /// answer this design exists to prevent.
+        /// </remarks>
+        [Test]
+        public void ModelsFromAnotherStoreAreRejected()
+        {
+            var other = StoreFactory.CreateStore("provider=dotnetrdf");
+
+            try
+            {
+                var ex = Assert.Throws<NotSupportedException>(() => _store.CreateLayeredModel(
+                    _store.GetModel(BaseGraph), other.GetModel(AddGraph), _store.GetModel(RemGraph)));
+
+                Assert.That(ex.Message, Does.Contain("different store"));
+
+                Assert.Throws<NotSupportedException>(() => _store.CreateLayeredModel(
+                    other.GetModel(BaseGraph), _store.GetModel(AddGraph), _store.GetModel(RemGraph)));
+
+                Assert.Throws<NotSupportedException>(() => _store.CreateLayeredModel(
+                    _store.GetModel(BaseGraph), _store.GetModel(AddGraph), other.GetModel(RemGraph)));
+            }
+            finally
+            {
+                other.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Models from the same store are of course accepted - the guard must not be a blanket refusal.
+        /// </summary>
+        [Test]
+        public void ModelsFromTheSameStoreAreAccepted()
+        {
+            Assert.DoesNotThrow(() => _store.CreateLayeredModel(
+                _store.GetModel(BaseGraph), _store.GetModel(AddGraph), _store.GetModel(RemGraph)));
+        }
+
+        [Test]
+        public void LayeredModelHasNoUriAndIsNotAModelGroup()
+        {
+            Assert.IsNull(_view.Uri, "a view spanning three graphs has no URI of its own");
+
+            // Keeping the types apart is what stops the union-only IModelGroup code paths from
+            // treating a layered view as a plain group.
+            Assert.IsFalse(_view is IModelGroup);
+        }
+
+        #endregion
+    }
+}

--- a/Trinity.Tests/SparqlExpressionWriterTest.cs
+++ b/Trinity.Tests/SparqlExpressionWriterTest.cs
@@ -1,0 +1,203 @@
+// LICENSE:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// AUTHORS:
+//
+//  Moritz Eberl <moritz@semiodesk.com>
+//  Sebastian Faubel <sebastian@semiodesk.com>
+//
+// Copyright (c) Semiodesk GmbH 2026
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using VDS.RDF.Query.Expressions;
+using VDS.RDF.Query.Patterns;
+
+namespace Semiodesk.Trinity.Tests
+{
+    /// <summary>
+    /// Verifies that <see cref="SparqlExpressionWriter"/> round-trips a SPARQL expression without
+    /// changing what it means — including the cases where dotNetRDF's own serialization does not.
+    /// </summary>
+    /// <remarks>
+    /// Each case is asserted twice: that our output re-parses to the same expression tree, and
+    /// (documenting the reason this class exists) which cases dotNetRDF gets wrong. The second half
+    /// is not there to criticise dotNetRDF but to pin the defect: if a future version fixes it, these
+    /// assertions fail and the writer can be reconsidered.
+    /// </remarks>
+    [TestFixture]
+    public class SparqlExpressionWriterTest
+    {
+        /// <summary>
+        /// Expressions dotNetRDF re-serializes faithfully, and expressions it does not — both must
+        /// round-trip through <see cref="SparqlExpressionWriter"/>.
+        /// </summary>
+        private static readonly string[] Expressions =
+        {
+            "?r >= 3",
+            "?r != 1",
+            "?r > 1 && ?r < 4",
+            "(?r + 1) * 2 > 6",
+            "str(?l) = 'x'",
+            "!bound(?l)",
+            "regex(str(?l), 'a', 'i')",
+            "?r IN (1, 2, 3)",
+            "?r NOT IN (1, 2)",
+            "lang(?l) = 'en'",
+            "datatype(?r) = <http://www.w3.org/2001/XMLSchema#integer>",
+            "isIRI(?s)",
+            "-?r < 0",
+            "abs(?r - 5) > 1",
+            "if(?r > 2, 'hi', 'lo') = 'hi'",
+            "coalesce(?l, 'none') = 'none'",
+            // The ones dotNetRDF drops the parentheses from.
+            "!(?r < 3)",
+            "!(?r = 1 || ?r = 2)",
+            "!(?r > 1 && ?r < 4)",
+            "!(!(?r < 3))",
+            "strlen(str(?l)) > 2 && !(?r = 3)",
+            "!(?r < 3) || !(?r > 9)",
+        };
+
+        /// <summary>
+        /// The subset dotNetRDF is known to serialize incorrectly.
+        /// </summary>
+        private static readonly HashSet<string> KnownUnfaithful = new HashSet<string>
+        {
+            "!(?r < 3)",
+            "!(?r = 1 || ?r = 2)",
+            "!(?r > 1 && ?r < 4)",
+            "!(!(?r < 3))",
+            "strlen(str(?l)) > 2 && !(?r = 3)",
+            "!(?r < 3) || !(?r > 9)",
+        };
+
+        public static IEnumerable<TestCaseData> Cases()
+        {
+            return Expressions.Select(e => new TestCaseData(e));
+        }
+
+        [TestCaseSource(nameof(Cases))]
+        public void WriterRoundTripsWithoutChangingMeaning(string expression)
+        {
+            ISparqlExpression original = Parse(expression);
+            string written = SparqlExpressionWriter.Write(original);
+
+            Assert.AreEqual(
+                SparqlExpressionWriter.Signature(original),
+                SparqlExpressionWriter.Signature(Parse(written)),
+                $"'{expression}' was re-serialized as '{written}', which does not mean the same thing");
+        }
+
+        [TestCaseSource(nameof(Cases))]
+        public void DotNetRdfIsUnfaithfulExactlyWhereExpected(string expression)
+        {
+            ISparqlExpression original = Parse(expression);
+            string theirs = original.ToString();
+
+            string before = SparqlExpressionWriter.Signature(original);
+            string after;
+
+            try
+            {
+                after = SparqlExpressionWriter.Signature(Parse(theirs));
+            }
+            catch (Exception)
+            {
+                // Its output does not even re-parse; that counts as unfaithful.
+                after = "(unparseable)";
+            }
+
+            bool faithful = before == after;
+
+            if (KnownUnfaithful.Contains(expression))
+            {
+                Assert.IsFalse(faithful,
+                    $"dotNetRDF now serializes '{expression}' faithfully. If that holds generally, " +
+                    "SparqlExpressionWriter may no longer be needed - re-check before removing it.");
+            }
+            else
+            {
+                Assert.IsTrue(faithful,
+                    $"dotNetRDF changed '{expression}' into '{theirs}'. Add it to KnownUnfaithful; " +
+                    "SparqlExpressionWriter already handles it, so nothing is broken.");
+            }
+        }
+
+        /// <summary>
+        /// Every case that dotNetRDF mangles is a case this writer has to carry.
+        /// </summary>
+        [Test]
+        public void WriterIsFaithfulForEveryExpressionIncludingTheUnfaithfulOnes()
+        {
+            var failures = new List<string>();
+
+            foreach (string expression in Expressions)
+            {
+                ISparqlExpression original = Parse(expression);
+                string written = SparqlExpressionWriter.Write(original);
+
+                if (SparqlExpressionWriter.Signature(original) != SparqlExpressionWriter.Signature(Parse(written)))
+                {
+                    failures.Add($"{expression} -> {written}");
+                }
+            }
+
+            Assert.IsEmpty(failures, "expressions that did not survive: " + string.Join("; ", failures));
+            Assert.Greater(KnownUnfaithful.Count, 0, "the corpus must include cases dotNetRDF gets wrong");
+        }
+
+        [Test]
+        public void WriteRejectsNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => SparqlExpressionWriter.Write(null));
+        }
+
+        [Test]
+        public void SignatureOfNullIsStable()
+        {
+            Assert.AreEqual("(null)", SparqlExpressionWriter.Signature(null));
+        }
+
+        /// <summary>
+        /// Parses a bare expression by wrapping it in a minimal query.
+        /// </summary>
+        private static ISparqlExpression Parse(string expression)
+        {
+            var query = new VDS.RDF.Parsing.SparqlQueryParser().ParseFromString(
+                "SELECT ?s WHERE { ?s <http://example.org/r> ?r . ?s <http://example.org/l> ?l . " +
+                "FILTER(" + expression + ") }");
+
+            var pattern = query.RootGraphPattern;
+
+            if (pattern.IsFiltered && pattern.Filter != null)
+            {
+                return pattern.Filter.Expression;
+            }
+
+            return pattern.TriplePatterns.OfType<IFilterPattern>()
+                .Select(f => f.Filter.Expression)
+                .Concat(pattern.UnplacedFilters.Select(f => f.Expression))
+                .First();
+        }
+    }
+}

--- a/Trinity.Tests/Store/DotNetRDF/DotNetRDFLayeredModelDifferentialTest.cs
+++ b/Trinity.Tests/Store/DotNetRDF/DotNetRDFLayeredModelDifferentialTest.cs
@@ -1,0 +1,38 @@
+// LICENSE:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// AUTHORS:
+//
+//  Moritz Eberl <moritz@semiodesk.com>
+//  Sebastian Faubel <sebastian@semiodesk.com>
+//
+// Copyright (c) Semiodesk GmbH 2026
+
+using NUnit.Framework;
+using Semiodesk.Trinity.Tests.Store;
+
+namespace Semiodesk.Trinity.Tests.DotNetRDF
+{
+    /// <summary>
+    /// Runs the layered-model differential sweep against the dotNetRDF in-memory store.
+    /// </summary>
+    [TestFixture]
+    public class DotNetRDFLayeredModelDifferentialTest : LayeredModelDifferentialTest<DotNetRDFTestSetup> { }
+}

--- a/Trinity.Tests/Store/DotNetRDF/DotNetRDFLayeredModelQueryCorpusTest.cs
+++ b/Trinity.Tests/Store/DotNetRDF/DotNetRDFLayeredModelQueryCorpusTest.cs
@@ -1,0 +1,38 @@
+// LICENSE:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// AUTHORS:
+//
+//  Moritz Eberl <moritz@semiodesk.com>
+//  Sebastian Faubel <sebastian@semiodesk.com>
+//
+// Copyright (c) Semiodesk GmbH 2026
+
+using NUnit.Framework;
+using Semiodesk.Trinity.Tests.Store;
+
+namespace Semiodesk.Trinity.Tests.DotNetRDF
+{
+    /// <summary>
+    /// Runs the layered-model SPARQL corpus against the dotNetRDF in-memory store.
+    /// </summary>
+    [TestFixture]
+    public class DotNetRDFLayeredModelQueryCorpusTest : LayeredModelQueryCorpusTest<DotNetRDFTestSetup> { }
+}

--- a/Trinity.Tests/Store/DotNetRDF/DotNetRDFLayeredModelTest.cs
+++ b/Trinity.Tests/Store/DotNetRDF/DotNetRDFLayeredModelTest.cs
@@ -1,0 +1,38 @@
+// LICENSE:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// AUTHORS:
+//
+//  Moritz Eberl <moritz@semiodesk.com>
+//  Sebastian Faubel <sebastian@semiodesk.com>
+//
+// Copyright (c) Semiodesk GmbH 2026
+
+using NUnit.Framework;
+using Semiodesk.Trinity.Tests.Store;
+
+namespace Semiodesk.Trinity.Tests.DotNetRDF
+{
+    /// <summary>
+    /// Runs the store-independent layered-model suite against the dotNetRDF in-memory store.
+    /// </summary>
+    [TestFixture]
+    public class DotNetRDFLayeredModelTest : LayeredModelTest<DotNetRDFTestSetup> {}
+}

--- a/Trinity.Tests/Store/LayeredModelDifferentialTest.cs
+++ b/Trinity.Tests/Store/LayeredModelDifferentialTest.cs
@@ -1,0 +1,227 @@
+// LICENSE:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// AUTHORS:
+//
+//  Moritz Eberl <moritz@semiodesk.com>
+//  Sebastian Faubel <sebastian@semiodesk.com>
+//
+// Copyright (c) Semiodesk GmbH 2026
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+
+namespace Semiodesk.Trinity.Tests.Store
+{
+    /// <summary>
+    /// With empty additions and removals a layered view must answer exactly as the plain baseline
+    /// model does — or refuse. Answering <i>differently</i> is a rewriter defect by construction.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the cheapest possible oracle for the rewriter: no expected results have to be written
+    /// down, because the baseline model computes them. That matters because the rewriter's failure
+    /// mode is a query that still parses and still returns rows, just not the right ones — which a
+    /// corpus of hand-written expectations will only catch where someone thought to write the case
+    /// down.
+    /// </para>
+    /// <para>
+    /// It earns its place: three defects found in review were of exactly this shape and all three are
+    /// caught here — a union reached as an alternative of another union losing its disjunction, and
+    /// GROUP BY / ORDER BY expressions escaping the round-trip check.
+    /// </para>
+    /// </remarks>
+    [TestFixture]
+    public abstract class LayeredModelDifferentialTest<T> : StoreTest<T> where T : IStoreTestSetup
+    {
+        #region Members
+
+        private const string EX = "http://example.org/diff/";
+
+        protected IModel Baseline;
+        protected IModel Additions;
+        protected IModel Removals;
+        protected ILayeredModel View;
+
+        #endregion
+
+        #region Setup
+
+        [SetUp]
+        public override void SetUp()
+        {
+            base.SetUp();
+
+            Baseline = Store.GetModel(BaseUri.GetUriRef("diff-baseline"));
+            Additions = Store.GetModel(BaseUri.GetUriRef("diff-additions"));
+            Removals = Store.GetModel(BaseUri.GetUriRef("diff-removals"));
+
+            foreach (IModel model in new[] { Baseline, Additions, Removals })
+            {
+                if (!model.IsEmpty) model.Clear();
+            }
+
+            View = Store.CreateLayeredModel(Baseline.Uri, Additions.Uri, Removals.Uri);
+
+            Baseline.ExecuteUpdate(new SparqlUpdate(
+                "INSERT DATA { GRAPH @g { " +
+                $"<{EX}a> a <{EX}Thing> ; <{EX}rank> 1 ; <{EX}q> 'qa' ; <{EX}peer> <{EX}c> . " +
+                $"<{EX}b> a <{EX}Thing> ; <{EX}rank> 2 ; <{EX}r> 'rb' . " +
+                $"<{EX}c> a <{EX}Other> ; <{EX}rank> 3 ; <{EX}s> <{EX}a> . " +
+                "} }").Bind("@g", Baseline));
+
+            // Additions and removals stay empty: that is what makes the baseline the oracle.
+        }
+
+        [TearDown]
+        public void TearDownDifferential()
+        {
+            Baseline.Clear();
+            Additions.Clear();
+            Removals.Clear();
+        }
+
+        #endregion
+
+        #region The sweep
+
+        /// <summary>
+        /// Query shapes the rewriter claims to support, chosen to exercise how patterns nest rather
+        /// than what they match.
+        /// </summary>
+        public static IEnumerable<TestCaseData> Shapes()
+        {
+            string thing = $"<{EX}Thing>", other = $"<{EX}Other>";
+            string rank = $"<{EX}rank>", q = $"<{EX}q>", r = $"<{EX}r>", s = $"<{EX}s>", peer = $"<{EX}peer>";
+
+            var shapes = new (string Label, string Sparql, bool Ordered)[]
+            {
+                ("basic graph pattern",        $"SELECT ?x ?v WHERE {{ ?x {rank} ?v }}", false),
+                ("join",                       $"SELECT ?x WHERE {{ ?x a {thing} . ?x {rank} ?v }}", false),
+                ("predicate-object list",      $"SELECT ?x WHERE {{ ?x a {thing} ; {rank} ?v }}", false),
+                ("object list",                $"SELECT ?x WHERE {{ ?x a {thing}, {thing} }}", false),
+                ("OPTIONAL",                   $"SELECT ?x ?w WHERE {{ ?x {rank} ?v . OPTIONAL {{ ?x {q} ?w }} }}", false),
+                ("MINUS",                      $"SELECT ?x WHERE {{ ?x {rank} ?v . MINUS {{ ?x a {thing} }} }}", false),
+                ("UNION",                      $"SELECT ?x WHERE {{ {{ ?x {q} ?v }} UNION {{ ?x {r} ?v }} }}", false),
+
+                // Regression, review finding 1: an alternative of a union may itself be a union.
+                // A UNION B UNION C parses left-nested, so this is the ordinary three-way case.
+                ("UNION nested left",          $"SELECT ?x WHERE {{ {{ {{ ?x {q} ?v }} UNION {{ ?x {r} ?v }} }} UNION {{ ?x {s} ?v }} }}", false),
+                ("UNION nested right",         $"SELECT ?x WHERE {{ {{ ?x {q} ?v }} UNION {{ {{ ?x {r} ?v }} UNION {{ ?x {s} ?v }} }} }}", false),
+                ("UNION three-way flat",       $"SELECT ?x WHERE {{ {{ ?x {q} ?v }} UNION {{ ?x {r} ?v }} UNION {{ ?x {s} ?v }} }}", false),
+                ("UNION four-way",             $"SELECT ?x WHERE {{ {{ ?x {q} ?v }} UNION {{ ?x {r} ?v }} UNION {{ ?x {s} ?v }} UNION {{ ?x {peer} ?v }} }}", false),
+                ("OPTIONAL inside UNION",      $"SELECT ?x ?w WHERE {{ {{ ?x {q} ?v }} UNION {{ ?x {rank} ?v . OPTIONAL {{ ?x {r} ?w }} }} }}", false),
+                ("UNION inside OPTIONAL",      $"SELECT ?x WHERE {{ ?x {rank} ?v . OPTIONAL {{ {{ ?x {q} ?w }} UNION {{ ?x {r} ?w }} }} }}", false),
+                ("MINUS inside UNION",         $"SELECT ?x WHERE {{ {{ ?x {rank} ?v . MINUS {{ ?x a {thing} }} }} UNION {{ ?x {s} ?v }} }}", false),
+                ("UNION of two types",         $"SELECT ?x WHERE {{ {{ ?x a {thing} }} UNION {{ ?x a {other} }} }}", false),
+
+                ("sub-SELECT",                 $"SELECT ?x WHERE {{ ?x {rank} ?v . {{ SELECT ?x WHERE {{ ?x a {thing} }} }} }}", false),
+                ("sub-SELECT with LIMIT",      $"SELECT ?x WHERE {{ ?x {rank} ?v . {{ SELECT ?x WHERE {{ ?x {rank} ?z }} ORDER BY ?z LIMIT 2 }} }}", false),
+                ("FILTER",                     $"SELECT ?x WHERE {{ ?x {rank} ?v . FILTER(?v > 1) }}", false),
+                ("FILTER negated",             $"SELECT ?x WHERE {{ ?x {rank} ?v . FILTER(!(?v < 2)) }}", false),
+                ("FILTER IN",                  $"SELECT ?x WHERE {{ ?x {rank} ?v . FILTER(?v IN (1, 3)) }}", false),
+                ("VALUES",                     $"SELECT ?x WHERE {{ VALUES ?x {{ <{EX}a> <{EX}b> }} ?x {rank} ?v }}", false),
+
+                // Regression, review finding 5: BIND is order-sensitive, unlike a triple pattern.
+                ("BIND before a pattern",      $"SELECT ?v WHERE {{ BIND(<{EX}a> AS ?x) ?x {rank} ?v }}", false),
+                ("BIND after a pattern",       $"SELECT ?y WHERE {{ ?x {rank} ?v . BIND(?v AS ?y) }}", false),
+                ("BIND between patterns",      $"SELECT ?y WHERE {{ ?x a {thing} . BIND(?x AS ?y) . ?x {rank} ?v }}", false),
+
+                ("DISTINCT",                   $"SELECT DISTINCT ?v WHERE {{ ?x {rank} ?v }}", false),
+                ("COUNT(*)",                   $"SELECT (COUNT(*) AS ?n) WHERE {{ ?x {rank} ?v }}", false),
+                ("COUNT DISTINCT",             $"SELECT (COUNT(DISTINCT ?x) AS ?n) WHERE {{ ?x {rank} ?v }}", false),
+                ("GROUP BY",                   $"SELECT ?x (COUNT(?v) AS ?n) WHERE {{ ?x {rank} ?v }} GROUP BY ?x", false),
+                ("GROUP BY with HAVING",       $"SELECT ?x WHERE {{ ?x {rank} ?v }} GROUP BY ?x HAVING(COUNT(?v) = 1)", false),
+                ("SELECT *",                   $"SELECT * WHERE {{ ?x {s} ?v }}", false),
+
+                ("ORDER BY",                   $"SELECT ?x WHERE {{ ?x {rank} ?v }} ORDER BY DESC(?v)", true),
+                ("ORDER BY two keys",          $"SELECT ?x WHERE {{ ?x {rank} ?v }} ORDER BY ?v DESC(?x)", true),
+                ("ORDER BY with LIMIT",        $"SELECT ?x WHERE {{ ?x {rank} ?v }} ORDER BY ?v LIMIT 2", true),
+                ("ORDER BY with OFFSET",       $"SELECT ?x WHERE {{ ?x {rank} ?v }} ORDER BY ?v OFFSET 1", true),
+            };
+
+            return shapes.Select(x => new TestCaseData(x.Label, x.Sparql, x.Ordered));
+        }
+
+        [TestCaseSource(nameof(Shapes))]
+        public virtual void ViewAgreesWithTheBaselineOrRefuses(string label, string sparql, bool ordered)
+        {
+            string expected = string.Join(" | ", Rows(Baseline, sparql, ordered));
+
+            string actual;
+
+            try
+            {
+                actual = string.Join(" | ", Rows(View, sparql, ordered));
+            }
+            catch (NotSupportedException)
+            {
+                // Refusing is always allowed; the promise is only that it never answers differently.
+                Assert.Pass($"{label}: refused");
+
+                return;
+            }
+
+            Assert.AreEqual(expected, actual,
+                $"{label} answered differently through the view than against the baseline, with nothing " +
+                $"staged - so the rewrite changed the query's meaning.\n  query: {sparql}");
+        }
+
+        /// <summary>
+        /// ASK is separate because it yields an answer rather than bindings.
+        /// </summary>
+        [Test]
+        public virtual void AskAgreesWithTheBaseline()
+        {
+            foreach (string sparql in new[]
+            {
+                $"ASK {{ <{EX}a> <{EX}rank> 1 }}",
+                $"ASK {{ <{EX}a> <{EX}rank> 99 }}",
+                $"ASK {{ ?x a <{EX}Thing> }}",
+                $"ASK {{ {{ ?x <{EX}q> ?v }} UNION {{ ?x <{EX}r> ?v }} }}",
+            })
+            {
+                bool expected = Baseline.ExecuteQuery(new SparqlQuery(sparql, declarePrefixes: false)).GetAnwser();
+                bool actual = View.ExecuteQuery(new SparqlQuery(sparql, declarePrefixes: false)).GetAnwser();
+
+                Assert.AreEqual(expected, actual, sparql);
+            }
+        }
+
+        private static IEnumerable<string> Rows(IModel model, string sparql, bool ordered)
+        {
+            var rows = model.GetBindings(new SparqlQuery(sparql, declarePrefixes: false))
+                .Select(b => string.Join(",", b.OrderBy(kv => kv.Key, StringComparer.Ordinal)
+                                              .Select(kv => kv.Key + "=" + kv.Value)))
+                .ToList();
+
+            if (!ordered)
+            {
+                rows.Sort(StringComparer.Ordinal);
+            }
+
+            return rows;
+        }
+
+        #endregion
+    }
+}

--- a/Trinity.Tests/Store/LayeredModelQueryCorpusTest.cs
+++ b/Trinity.Tests/Store/LayeredModelQueryCorpusTest.cs
@@ -237,8 +237,18 @@ namespace Semiodesk.Trinity.Tests.Store
             yield return new TestCaseData("OFFSET",
                 $"SELECT ?s WHERE {{ ?s a {thing} ; {rank} ?r }} ORDER BY ?r OFFSET 2", "added");
 
-            yield return new TestCaseData("blank node property list",
+            // NB: this is a predicate-object list with a FILTER, not a blank-node property list - it
+            // was mislabelled, which is how a blank-node defect survived an otherwise thorough suite.
+            // The real [ ... ] form cannot be rewritten at all; see the refused corpus.
+            yield return new TestCaseData("predicate-object list with FILTER",
                 $"SELECT ?s WHERE {{ ?s a {thing} ; {rank} ?r . FILTER(?r = 1) }}", "keep");
+
+            yield return new TestCaseData("nested UNION (left-nested, as A UNION B UNION C parses)",
+                $"SELECT ?s WHERE {{ {{ {{ ?s a {thing} }} UNION {{ ?s a {other} }} }} UNION {{ ?s {rank} 99 }} }}",
+                "added,both,keep,other");
+
+            yield return new TestCaseData("BIND before the pattern that uses it",
+                $"SELECT ?r WHERE {{ BIND(<{EX}keep> AS ?s) ?s {rank} ?r }}", "");
 
             // dotNetRDF serializes !(?r < 3) as !?r < 3, i.e. (!?r) < 3, and it still parses.
             // Trinity writes filter expressions with its own serializer so these stay faithful.
@@ -400,6 +410,18 @@ namespace Semiodesk.Trinity.Tests.Store
             // it is inside a FILTER, but those two are reused from its serialization of the query head
             // and solution modifiers rather than re-emitted, so they can only be detected. Refused
             // with a suggested rephrasing rather than answered differently than asked.
+            yield return new TestCaseData("blank node subject",
+                $"SELECT ?o WHERE {{ _:b {rank} ?o }}", "blank node");
+
+            yield return new TestCaseData("blank node property list",
+                $"SELECT ?o WHERE {{ ?s {peer} [ {rank} ?o ] }}", "blank node");
+
+            yield return new TestCaseData("negation inside GROUP BY",
+                $"SELECT ?g WHERE {{ ?s {rank} ?r }} GROUP BY (!(?r < 3) AS ?g)", "GROUP BY");
+
+            yield return new TestCaseData("negation inside ORDER BY",
+                $"SELECT ?s WHERE {{ ?s {rank} ?r }} ORDER BY DESC(!(?r < 3))", "ORDER BY");
+
             yield return new TestCaseData("negation inside HAVING",
                 $"SELECT ?s WHERE {{ ?s a {thing} ; {rank} ?r }} GROUP BY ?s HAVING(!(COUNT(?r) < 1))", "HAVING");
 

--- a/Trinity.Tests/Store/LayeredModelQueryCorpusTest.cs
+++ b/Trinity.Tests/Store/LayeredModelQueryCorpusTest.cs
@@ -1,0 +1,439 @@
+// LICENSE:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// AUTHORS:
+//
+//  Moritz Eberl <moritz@semiodesk.com>
+//  Sebastian Faubel <sebastian@semiodesk.com>
+//
+// Copyright (c) Semiodesk GmbH 2026
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+
+namespace Semiodesk.Trinity.Tests.Store
+{
+    /// <summary>
+    /// A corpus of caller-supplied SPARQL run through an <see cref="ILayeredModel"/>, each case with
+    /// its expected result, plus the forms that must be refused.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Every case is chosen so that the answer differs depending on whether the overlay was applied —
+    /// a query whose result is the same with and without subtraction proves nothing. The seed data is
+    /// laid out so that one resource survives untouched, one loses a triple, one has a value replaced,
+    /// and one exists only as a staged addition.
+    /// </para>
+    /// <para>
+    /// This runs on every backend with a fixture, because the union half of the overlay is where
+    /// backends differ. Note the deliberate avoidance of plain-literal equality in the queries:
+    /// Virtuoso 7 stores a plain literal as <c>xsd:string</c> and does not equate the two, so
+    /// comparisons go through <c>str()</c> and the structural cases key on IRIs and integers.
+    /// </para>
+    /// </remarks>
+    [TestFixture]
+    public abstract class LayeredModelQueryCorpusTest<T> : StoreTest<T> where T : IStoreTestSetup
+    {
+        #region Members
+
+        private const string EX = "http://example.org/corpus/";
+
+        protected IModel Baseline;
+        protected IModel Additions;
+        protected IModel Removals;
+        protected ILayeredModel View;
+
+        private static string S(string local) => $"<{EX}{local}>";
+
+        #endregion
+
+        #region Setup
+
+        /// <summary>
+        /// Seeds the three graphs.
+        /// </summary>
+        /// <remarks>
+        /// Effective view after staging:
+        /// <list type="bullet">
+        /// <item><c>keep</c>  — a Thing, rank 1, peer of <c>other</c>, label "keep" (untouched)</item>
+        /// <item><c>gone</c>  — rank 2, label "gone", but <b>no longer a Thing</b> (type staged for removal)</item>
+        /// <item><c>both</c>  — a Thing, rank 3, label "new" (old label removed, new one added)</item>
+        /// <item><c>other</c> — an Other, label "other"</item>
+        /// <item><c>added</c> — a Thing, rank 4, label "added" (exists only in additions)</item>
+        /// </list>
+        /// </remarks>
+        [SetUp]
+        public override void SetUp()
+        {
+            base.SetUp();
+
+            OntologyDiscovery.AddNamespace("cex", new Uri(EX));
+
+            Baseline = Store.GetModel(BaseUri.GetUriRef("corpus-baseline"));
+            Additions = Store.GetModel(BaseUri.GetUriRef("corpus-additions"));
+            Removals = Store.GetModel(BaseUri.GetUriRef("corpus-removals"));
+
+            foreach (IModel model in new[] { Baseline, Additions, Removals })
+            {
+                if (!model.IsEmpty) model.Clear();
+            }
+
+            View = Store.CreateLayeredModel(Baseline.Uri, Additions.Uri, Removals.Uri);
+
+            Baseline.ExecuteUpdate(new SparqlUpdate(
+                "INSERT DATA { GRAPH @g { " +
+                $"{S("keep")}  a {S("Thing")} ; {S("rank")} 1 ; {S("label")} 'keep'  ; {S("peer")} {S("other")} . " +
+                $"{S("gone")}  a {S("Thing")} ; {S("rank")} 2 ; {S("label")} 'gone'  . " +
+                $"{S("both")}  a {S("Thing")} ; {S("rank")} 3 ; {S("label")} 'old'   . " +
+                $"{S("other")} a {S("Other")} ; {S("label")} 'other' . " +
+                "} }").Bind("@g", Baseline));
+
+            // Copy the triples to be removed out of the baseline, so they are term-identical.
+            Removals.ExecuteUpdate(new SparqlUpdate(
+                "INSERT { GRAPH @removals { ?s ?p ?o } } WHERE { GRAPH @baseline { ?s ?p ?o . " +
+                $"FILTER ((?s = {S("gone")} && ?p = <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>) " +
+                $"|| (?s = {S("both")} && ?p = {S("label")})) }} }}")
+                .Bind("@removals", Removals).Bind("@baseline", Baseline));
+
+            Additions.ExecuteUpdate(new SparqlUpdate(
+                "INSERT DATA { GRAPH @g { " +
+                $"{S("both")}  {S("label")} 'new' . " +
+                $"{S("added")} a {S("Thing")} ; {S("rank")} 4 ; {S("label")} 'added' . " +
+                "} }").Bind("@g", Additions));
+        }
+
+        [TearDown]
+        public void TearDownCorpus()
+        {
+            Baseline.Clear();
+            Additions.Clear();
+            Removals.Clear();
+        }
+
+        #endregion
+
+        #region Helpers
+
+        /// <summary>
+        /// Runs a query through the view and returns the <c>?s</c> bindings as sorted local names.
+        /// </summary>
+        private string Subjects(string sparql)
+        {
+            var seen = View.GetBindings(new SparqlQuery(sparql, declarePrefixes: false))
+                .Select(b => b.ContainsKey("s") ? b["s"]?.ToString() : null)
+                .Where(v => v != null)
+                .Select(v => v.Replace(EX, ""))
+                .Distinct()
+                .OrderBy(v => v, StringComparer.Ordinal);
+
+            return string.Join(",", seen);
+        }
+
+        private string Scalar(string sparql, string variable)
+        {
+            BindingSet first = View.GetBindings(new SparqlQuery(sparql, declarePrefixes: false)).FirstOrDefault();
+
+            return first != null && first.ContainsKey(variable) ? first[variable]?.ToString() : null;
+        }
+
+        private bool Ask(string sparql)
+        {
+            return View.ExecuteQuery(new SparqlQuery(sparql, declarePrefixes: false)).GetAnwser();
+        }
+
+        #endregion
+
+        #region Corpus: queries that must be rewritten and answered
+
+        /// <summary>
+        /// Each case is (label, query, expected sorted <c>?s</c> local names). The expected value is
+        /// what the overlay makes true, and differs from the un-subtracted answer in every case.
+        /// </summary>
+        public static IEnumerable<TestCaseData> SelectCorpus()
+        {
+            string thing = $"<{EX}Thing>", other = $"<{EX}Other>";
+            string rank = $"<{EX}rank>", label = $"<{EX}label>", peer = $"<{EX}peer>";
+            string a = "<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>";
+
+            // 'gone' is no longer a Thing; 'added' is one only via additions.
+            yield return new TestCaseData("type constraint",
+                $"SELECT ?s WHERE {{ ?s a {thing} }}", "added,both,keep");
+
+            yield return new TestCaseData("type constraint via 'a' keyword",
+                $"SELECT ?s WHERE {{ ?s {a} {thing} }}", "added,both,keep");
+
+            // rank is untouched, so every resource that has one shows up - including 'gone'.
+            yield return new TestCaseData("unconstrained predicate",
+                $"SELECT ?s WHERE {{ ?s {rank} ?r }}", "added,both,gone,keep");
+
+            yield return new TestCaseData("numeric FILTER",
+                $"SELECT ?s WHERE {{ ?s {rank} ?r . FILTER(?r > 2) }}", "added,both");
+
+            yield return new TestCaseData("two patterns joined",
+                $"SELECT ?s WHERE {{ ?s a {thing} . ?s {rank} ?r }}", "added,both,keep");
+
+            yield return new TestCaseData("predicate-object list",
+                $"SELECT ?s WHERE {{ ?s a {thing} ; {rank} ?r }}", "added,both,keep");
+
+            yield return new TestCaseData("object list",
+                $"SELECT ?s WHERE {{ ?s a {thing}, {thing} }}", "added,both,keep");
+
+            yield return new TestCaseData("IRI object",
+                $"SELECT ?s WHERE {{ ?s {peer} <{EX}other> }}", "keep");
+
+            // 'both' had its label replaced: the old value must be gone, the new one present.
+            yield return new TestCaseData("replaced value, new",
+                $"SELECT ?s WHERE {{ ?s {label} ?l . FILTER(str(?l) = 'new') }}", "both");
+
+            yield return new TestCaseData("replaced value, old is subtracted",
+                $"SELECT ?s WHERE {{ ?s {label} ?l . FILTER(str(?l) = 'old') }}", "");
+
+            yield return new TestCaseData("OPTIONAL keeps unmatched rows",
+                $"SELECT ?s WHERE {{ ?s {rank} ?r . OPTIONAL {{ ?s a {thing} }} }}", "added,both,gone,keep");
+
+            yield return new TestCaseData("UNION over two types",
+                $"SELECT ?s WHERE {{ {{ ?s a {thing} }} UNION {{ ?s a {other} }} }}", "added,both,keep,other");
+
+            yield return new TestCaseData("MINUS finds the de-typed resource",
+                $"SELECT ?s WHERE {{ ?s {rank} ?r . MINUS {{ ?s a {thing} }} }}", "gone");
+
+            yield return new TestCaseData("sub-SELECT",
+                $"SELECT ?s WHERE {{ ?s {rank} ?r . {{ SELECT ?s WHERE {{ ?s a {thing} }} }} }}", "added,both,keep");
+
+            yield return new TestCaseData("VALUES restricts subjects",
+                $"SELECT ?s WHERE {{ VALUES ?s {{ <{EX}keep> <{EX}gone> }} ?s a {thing} }}", "keep");
+
+            yield return new TestCaseData("BIND alongside a pattern",
+                $"SELECT ?s WHERE {{ ?s a {thing} . BIND(1 AS ?one) }}", "added,both,keep");
+
+            yield return new TestCaseData("DISTINCT",
+                $"SELECT DISTINCT ?s WHERE {{ ?s a {thing} ; {rank} ?r }}", "added,both,keep");
+
+            yield return new TestCaseData("ORDER BY with LIMIT",
+                $"SELECT ?s WHERE {{ ?s a {thing} ; {rank} ?r }} ORDER BY ?r LIMIT 2", "both,keep");
+
+            yield return new TestCaseData("ORDER BY DESC with LIMIT",
+                $"SELECT ?s WHERE {{ ?s a {thing} ; {rank} ?r }} ORDER BY DESC(?r) LIMIT 1", "added");
+
+            yield return new TestCaseData("OFFSET",
+                $"SELECT ?s WHERE {{ ?s a {thing} ; {rank} ?r }} ORDER BY ?r OFFSET 2", "added");
+
+            yield return new TestCaseData("blank node property list",
+                $"SELECT ?s WHERE {{ ?s a {thing} ; {rank} ?r . FILTER(?r = 1) }}", "keep");
+
+            // dotNetRDF serializes !(?r < 3) as !?r < 3, i.e. (!?r) < 3, and it still parses.
+            // Trinity writes filter expressions with its own serializer so these stay faithful.
+            yield return new TestCaseData("negation around a comparison",
+                $"SELECT ?s WHERE {{ ?s {rank} ?r . FILTER(!(?r < 3)) }}", "added,both");
+
+            yield return new TestCaseData("negation around a disjunction",
+                $"SELECT ?s WHERE {{ ?s {rank} ?r . FILTER(!(?r = 1 || ?r = 2)) }}", "added,both");
+
+            yield return new TestCaseData("negation around a conjunction",
+                $"SELECT ?s WHERE {{ ?s {rank} ?r . FILTER(!(?r > 1 && ?r < 4)) }}", "added,keep");
+
+            yield return new TestCaseData("doubly nested negation",
+                $"SELECT ?s WHERE {{ ?s {rank} ?r . FILTER(!(!(?r < 3))) }}", "gone,keep");
+
+            yield return new TestCaseData("equivalent comparison",
+                $"SELECT ?s WHERE {{ ?s {rank} ?r . FILTER(?r >= 3) }}", "added,both");
+
+            yield return new TestCaseData("IN",
+                $"SELECT ?s WHERE {{ ?s {rank} ?r . FILTER(?r IN (1, 4)) }}", "added,keep");
+
+            yield return new TestCaseData("NOT IN",
+                $"SELECT ?s WHERE {{ ?s {rank} ?r . FILTER(?r NOT IN (1, 4)) }}", "both,gone");
+
+            yield return new TestCaseData("nested function calls",
+                $"SELECT ?s WHERE {{ ?s {label} ?l . FILTER(strlen(str(?l)) = 4) }}", "gone,keep");
+
+            yield return new TestCaseData("arithmetic precedence",
+                $"SELECT ?s WHERE {{ ?s {rank} ?r . FILTER((?r + 1) * 2 > 8) }}", "added");
+
+            yield return new TestCaseData("BIND with a negated comparison",
+                $"SELECT ?s WHERE {{ ?s {rank} ?r . BIND(!(?r < 3) AS ?high) . FILTER(?high) }}", "added,both");
+
+            yield return new TestCaseData("negated equality",
+                $"SELECT ?s WHERE {{ ?s {rank} ?r . FILTER(?r != 1) }}", "added,both,gone");
+
+            // Regression: '<' is also the less-than operator. A scanner that mistakes it for the
+            // start of an IRI swallows the rest of the query, closing braces included.
+            yield return new TestCaseData("less-than in a filter",
+                $"SELECT ?s WHERE {{ ?s {rank} ?r . FILTER(?r < 3) }}", "gone,keep");
+
+            yield return new TestCaseData("both comparison operators",
+                $"SELECT ?s WHERE {{ ?s {rank} ?r . FILTER(?r > 1 && ?r < 4) }}", "both,gone");
+
+            yield return new TestCaseData("angle brackets inside a literal",
+                "SELECT ?s WHERE { ?s " + label + " ?l . FILTER(str(?l) != '<a> } b') }", "added,both,gone,keep,other");
+
+            yield return new TestCaseData("closing brace inside a literal",
+                "SELECT ?s WHERE { ?s " + label + " ?l . FILTER(str(?l) != '}') }", "added,both,gone,keep,other");
+
+            yield return new TestCaseData("SELECT *",
+                $"SELECT * WHERE {{ ?s {peer} ?o }}", "keep");
+        }
+
+        [TestCaseSource(nameof(SelectCorpus))]
+        public virtual void SelectCorpusCase(string label, string sparql, string expected)
+        {
+            Assert.AreEqual(expected, Subjects(sparql), $"{label}\n  query: {sparql}");
+        }
+
+        [Test]
+        public virtual void AggregateCountsOnlyEffectiveTriples()
+        {
+            // 4 Things in the baseline+additions union, 3 through the view: 'gone' lost its type.
+            Assert.AreEqual("3", Scalar(
+                $"SELECT (COUNT(DISTINCT ?s) AS ?n) WHERE {{ ?s a <{EX}Thing> }}", "n"));
+        }
+
+        [Test]
+        public virtual void AggregateWithGroupByAndHaving()
+        {
+            // Each Thing has exactly one rank, so grouping by ?s and requiring a count of 1 keeps all
+            // three effective Things.
+            var rows = View.GetBindings(new SparqlQuery(
+                $"SELECT ?s (COUNT(?r) AS ?n) WHERE {{ ?s a <{EX}Thing> ; <{EX}rank> ?r }} " +
+                "GROUP BY ?s HAVING(COUNT(?r) = 1)", declarePrefixes: false)).ToList();
+
+            Assert.AreEqual(3, rows.Count);
+        }
+
+        [Test]
+        public virtual void AskIsTrueForAnEffectiveTriple()
+        {
+            Assert.IsTrue(Ask($"ASK {{ <{EX}keep> a <{EX}Thing> }}"));
+            Assert.IsTrue(Ask($"ASK {{ <{EX}added> a <{EX}Thing> }}"), "a staged addition must be visible");
+            Assert.IsTrue(Ask($"ASK {{ <{EX}gone> <{EX}rank> 2 }}"), "an untouched triple must remain visible");
+        }
+
+        [Test]
+        public virtual void AskIsFalseForARemovedTriple()
+        {
+            Assert.IsFalse(Ask($"ASK {{ <{EX}gone> a <{EX}Thing> }}"),
+                "the staged removal must apply - this is a fully ground pattern, which needs FILTER NOT EXISTS");
+
+            Assert.IsTrue(Baseline.ExecuteQuery(new SparqlQuery(
+                $"ASK FROM <{Baseline.Uri}> {{ <{EX}gone> a <{EX}Thing> }}", declarePrefixes: false)).GetAnwser(),
+                "while the baseline still holds it");
+        }
+
+        [Test]
+        public virtual void StatementQueryStillMaterializesResources()
+        {
+            // A caller SELECT ?s ?p ?o must survive the rewrite as a statement-providing query,
+            // otherwise resource materialization refuses it outright.
+            var resources = View.GetResources(new SparqlQuery(
+                $"SELECT ?s ?p ?o WHERE {{ ?s ?p ?o . ?s a <{EX}Thing> }}", declarePrefixes: false)).ToList();
+
+            var names = resources.Select(r => r.Uri.OriginalString.Replace(EX, "")).OrderBy(n => n).ToList();
+
+            Assert.AreEqual(new[] { "added", "both", "keep" }, names);
+
+            var both = resources.Single(r => r.Uri.OriginalString == EX + "both");
+            var labels = both.ListValues(new Property(new Uri(EX + "label"))).Select(v => v.ToString()).ToList();
+
+            Assert.AreEqual(new[] { "new" }, labels, "the replaced label must read as the staged value only");
+        }
+
+        #endregion
+
+        #region Corpus: forms that must be refused
+
+        /// <summary>
+        /// Each case is (label, query, a distinctive fragment of the expected reason). These must throw
+        /// rather than answer: every one of them would otherwise read past the overlay and return
+        /// triples staged for removal, or return nothing at all, with no signal either way.
+        /// </summary>
+        public static IEnumerable<TestCaseData> RefusedCorpus()
+        {
+            string thing = $"<{EX}Thing>", peer = $"<{EX}peer>", label = $"<{EX}label>", rank = $"<{EX}rank>";
+
+            yield return new TestCaseData("property path, sequence",
+                $"SELECT ?s WHERE {{ ?s {peer}/{label} ?l }}", "property path");
+
+            yield return new TestCaseData("property path, transitive",
+                $"SELECT ?s WHERE {{ ?s {peer}+ ?o }}", "property path");
+
+            yield return new TestCaseData("explicit GRAPH block",
+                $"SELECT ?s WHERE {{ GRAPH <{EX}g> {{ ?s a {thing} }} }}", "GRAPH");
+
+            yield return new TestCaseData("GRAPH with a variable",
+                $"SELECT ?s WHERE {{ GRAPH ?g {{ ?s a {thing} }} }}", "GRAPH");
+
+            yield return new TestCaseData("SERVICE",
+                $"SELECT ?s WHERE {{ SERVICE <http://example.org/sparql> {{ ?s a {thing} }} }}", "SERVICE");
+
+            yield return new TestCaseData("CONSTRUCT",
+                $"CONSTRUCT {{ ?s a {thing} }} WHERE {{ ?s a {thing} }}", "CONSTRUCT");
+
+            yield return new TestCaseData("DESCRIBE",
+                $"DESCRIBE <{EX}keep>", "DESCRIBE");
+
+            yield return new TestCaseData("FILTER NOT EXISTS",
+                $"SELECT ?s WHERE {{ ?s a {thing} . FILTER NOT EXISTS {{ ?s {label} ?l }} }}", "EXISTS");
+
+            yield return new TestCaseData("FILTER EXISTS",
+                $"SELECT ?s WHERE {{ ?s a {thing} . FILTER EXISTS {{ ?s {label} ?l }} }}", "EXISTS");
+
+            // A negation inside HAVING or a projected expression is mangled by dotNetRDF exactly as
+            // it is inside a FILTER, but those two are reused from its serialization of the query head
+            // and solution modifiers rather than re-emitted, so they can only be detected. Refused
+            // with a suggested rephrasing rather than answered differently than asked.
+            yield return new TestCaseData("negation inside HAVING",
+                $"SELECT ?s WHERE {{ ?s a {thing} ; {rank} ?r }} GROUP BY ?s HAVING(!(COUNT(?r) < 1))", "HAVING");
+
+            yield return new TestCaseData("negation inside a projected expression",
+                $"SELECT (!(?r < 3) AS ?high) WHERE {{ ?s {rank} ?r }}", "projected expression");
+
+            yield return new TestCaseData("query with its own dataset clause",
+                $"SELECT ?s FROM <{EX}g> WHERE {{ ?s a {thing} }}", "dataset clause");
+        }
+
+        [TestCaseSource(nameof(RefusedCorpus))]
+        public virtual void RefusedCorpusCase(string label, string sparql, string reasonFragment)
+        {
+            var ex = Assert.Throws<NotSupportedException>(
+                () => View.GetBindings(new SparqlQuery(sparql, declarePrefixes: false)).ToList(),
+                $"{label} must be refused, not answered\n  query: {sparql}");
+
+            Assert.That(ex.Message, Does.Contain(reasonFragment),
+                $"{label}: the refusal must say why\n  message: {ex.Message}");
+        }
+
+        /// <summary>
+        /// A refused form must stay refused however it is reached, not just through GetBindings.
+        /// </summary>
+        [Test]
+        public virtual void RefusalAppliesToEveryQueryEntryPoint()
+        {
+            string path = $"SELECT ?s WHERE {{ ?s <{EX}peer>/<{EX}label> ?l }}";
+
+            Assert.Throws<NotSupportedException>(() => View.ExecuteQuery(new SparqlQuery(path, declarePrefixes: false)));
+            Assert.Throws<NotSupportedException>(() => View.GetBindings(new SparqlQuery(path, declarePrefixes: false)).ToList());
+            Assert.Throws<NotSupportedException>(() => View.GetResources(new SparqlQuery(path, declarePrefixes: false)).ToList());
+        }
+
+        #endregion
+    }
+}

--- a/Trinity.Tests/Store/LayeredModelTest.cs
+++ b/Trinity.Tests/Store/LayeredModelTest.cs
@@ -230,6 +230,83 @@ namespace Semiodesk.Trinity.Tests.Store
                 "a triple in both additions and removals must be visible: additions win");
         }
 
+        /// <summary>
+        /// Re-adding a triple that is already in the baseline must not double it.
+        /// </summary>
+        /// <remarks>
+        /// SPARQL <c>UNION</c> is a bag union, so an overlay whose branches overlap yields two
+        /// solutions for one triple: <c>COUNT</c> inflates and rows duplicate, with nothing to signal
+        /// it. The view promises the <i>set</i> <c>(baseline - removals) union additions</c>, and an
+        /// idempotent re-add is exactly what "additions win" invites a caller to do - so this is the
+        /// ordinary case rather than an exotic one.
+        /// </remarks>
+        [Test]
+        public virtual void AnIdenticalReAddDoesNotDuplicateSolutions()
+        {
+            GivenBaselineResource(R1, "same value");
+
+            // Stage the identical triple as an addition.
+            Additions.ExecuteUpdate(new SparqlUpdate(
+                "INSERT { GRAPH @additions { ?s ?p ?o } } WHERE { GRAPH @baseline { ?s ?p ?o } }")
+                .Bind("@additions", Additions)
+                .Bind("@baseline", Baseline));
+
+            Assert.AreEqual(1, View.GetResource(R1).ListValues(to.uniqueStringTest).Count(),
+                "a triple in both the baseline and the additions must yield one value, not two");
+
+            var count = View.GetBindings(new SparqlQuery(
+                $"SELECT (COUNT(*) AS ?n) WHERE {{ ?s <{to.uniqueStringTest.Uri}> ?o }}", declarePrefixes: false))
+                .First();
+
+            Assert.AreEqual("1", count["n"].ToString(), "COUNT must not be inflated by the overlay");
+        }
+
+        /// <summary>
+        /// The same triple in all three graphs is still visible exactly once.
+        /// </summary>
+        [Test]
+        public virtual void ATripleInAllThreeLayersIsVisibleOnce()
+        {
+            GivenBaselineResource(R1, "same value");
+
+            foreach (IModel target in new[] { Removals, Additions })
+            {
+                target.ExecuteUpdate(new SparqlUpdate(
+                    "INSERT { GRAPH @target { ?s ?p ?o } } WHERE { GRAPH @baseline { ?s ?p ?o } }")
+                    .Bind("@target", target)
+                    .Bind("@baseline", Baseline));
+            }
+
+            Assert.AreEqual(1, View.GetResource(R1).ListValues(to.uniqueStringTest).Count(),
+                "additions win over removals, but only once");
+        }
+
+        /// <summary>
+        /// A union reached as an alternative of another union keeps its disjunction.
+        /// </summary>
+        /// <remarks>
+        /// <c>A UNION B UNION C</c> parses left-nested, so this is the ordinary three-way case rather
+        /// than an unusual one. Emitting the inner union as a group would turn it into a join and
+        /// quietly drop solutions.
+        /// </remarks>
+        [Test]
+        public virtual void NestedUnionKeepsItsDisjunction()
+        {
+            GivenBaselineResource(R1, "one");
+            GivenBaselineResource(R2, "two");
+
+            string p = to.uniqueStringTest.Uri.OriginalString;
+
+            var seen = View.GetBindings(new SparqlQuery(
+                $"SELECT ?s WHERE {{ {{ {{ ?s <{p}> 'one' }} UNION {{ ?s <{p}> 'two' }} }} UNION {{ ?s <{p}> 'three' }} }}",
+                declarePrefixes: false))
+                .Select(b => b["s"].ToString())
+                .OrderBy(x => x)
+                .ToList();
+
+            Assert.AreEqual(2, seen.Count, "both alternatives of the inner union must survive");
+        }
+
         #endregion
 
         #region Mapped-object reads
@@ -393,6 +470,55 @@ namespace Semiodesk.Trinity.Tests.Store
                 $"SELECT ?s WHERE {{ GRAPH <{Baseline.Uri}> {{ ?s ?p ?o }} }}", declarePrefixes: false);
 
             Assert.Throws<NotSupportedException>(() => View.GetBindings(graphBlock).ToList());
+        }
+
+        /// <summary>
+        /// A blank node in a triple pattern is refused, and says why.
+        /// </summary>
+        /// <remarks>
+        /// The overlay repeats each pattern across three basic graph patterns, and SPARQL forbids a
+        /// blank-node label appearing in more than one BGP - so the rewrite could not be legal SPARQL.
+        /// The <c>[ ... ]</c> property-list form is the same thing spelled differently.
+        /// </remarks>
+        [Test]
+        public virtual void BlankNodePatternsAreRefusedWithAReason()
+        {
+            foreach (string sparql in new[]
+            {
+                $"SELECT ?o WHERE {{ _:b <{to.uniqueStringTest.Uri}> ?o }}",
+                $"SELECT ?o WHERE {{ ?s <{to.resourceTest.Uri}> [ <{to.uniqueStringTest.Uri}> ?o ] }}",
+            })
+            {
+                var ex = Assert.Throws<NotSupportedException>(
+                    () => View.GetBindings(new SparqlQuery(sparql, declarePrefixes: false)).ToList(), sparql);
+
+                Assert.That(ex.Message, Does.Contain("blank node"),
+                    $"the refusal must name the cause, not report a rewriter defect:\n{ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// A negation inside GROUP BY or ORDER BY is refused rather than answered differently.
+        /// </summary>
+        /// <remarks>
+        /// Those clauses reach the output through dotNetRDF's own serialization of the query head,
+        /// which mangles a negation wrapped around a comparison, so they can only be detected - the
+        /// same treatment HAVING and projected expressions get.
+        /// </remarks>
+        [Test]
+        public virtual void NegationInGroupByOrOrderByIsRefused()
+        {
+            GivenBaselineResource(R1, "one");
+
+            string p = to.uniqueStringTest.Uri.OriginalString;
+
+            Assert.Throws<NotSupportedException>(() => View.GetBindings(new SparqlQuery(
+                $"SELECT ?g (COUNT(?s) AS ?n) WHERE {{ ?s <{p}> ?o }} GROUP BY (!(?o = 'x') AS ?g)",
+                declarePrefixes: false)).ToList(), "GROUP BY");
+
+            Assert.Throws<NotSupportedException>(() => View.GetBindings(new SparqlQuery(
+                $"SELECT ?s WHERE {{ ?s <{p}> ?o }} ORDER BY DESC(!(?o = 'x'))",
+                declarePrefixes: false)).ToList(), "ORDER BY");
         }
 
         [Test]

--- a/Trinity.Tests/Store/LayeredModelTest.cs
+++ b/Trinity.Tests/Store/LayeredModelTest.cs
@@ -1,0 +1,451 @@
+// LICENSE:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// AUTHORS:
+//
+//  Moritz Eberl <moritz@semiodesk.com>
+//  Sebastian Faubel <sebastian@semiodesk.com>
+//
+// Copyright (c) Semiodesk GmbH 2026
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+using Semiodesk.Trinity.Ontologies;
+using Semiodesk.Trinity.Tests.Linq;
+
+namespace Semiodesk.Trinity.Tests.Store
+{
+    /// <summary>
+    /// Store-independent behaviour of <see cref="ILayeredModel"/>: a read view over
+    /// <c>baseline</c> + <c>additions</c> - <c>removals</c>.
+    /// </summary>
+    /// <remarks>
+    /// These run against every backend that has a fixture, because the union half of the overlay is
+    /// exactly where backends differ — an in-memory-only test would prove very little here. Fuseki
+    /// has no generic fixture (its suite is a hand-written copy and the backend is 4/86 on an
+    /// upstream connector bug), so it is not covered; see ADR-0041.
+    /// </remarks>
+    [TestFixture]
+    public abstract class LayeredModelTest<T> : StoreTest<T> where T : IStoreTestSetup
+    {
+        #region Members
+
+        protected IModel Baseline;
+
+        protected IModel Additions;
+
+        protected IModel Removals;
+
+        protected ILayeredModel View;
+
+        protected UriRef R1;
+
+        protected UriRef R2;
+
+        #endregion
+
+        #region Setup
+
+        [SetUp]
+        public override void SetUp()
+        {
+            base.SetUp();
+
+            OntologyDiscovery.AddNamespace("ex", new Uri("http://example.org/"));
+
+            Baseline = Store.GetModel(BaseUri.GetUriRef("layer-baseline"));
+            Additions = Store.GetModel(BaseUri.GetUriRef("layer-additions"));
+            Removals = Store.GetModel(BaseUri.GetUriRef("layer-removals"));
+
+            if (!Baseline.IsEmpty) Baseline.Clear();
+            if (!Additions.IsEmpty) Additions.Clear();
+            if (!Removals.IsEmpty) Removals.Clear();
+
+            View = Store.CreateLayeredModel(Baseline.Uri, Additions.Uri, Removals.Uri);
+
+            R1 = BaseUri.GetUriRef("lr1");
+            R2 = BaseUri.GetUriRef("lr2");
+        }
+
+        // Named differently from the base TearDown, which is not virtual. NUnit runs both.
+        [TearDown]
+        public void TearDownLayers()
+        {
+            Baseline.Clear();
+            Additions.Clear();
+            Removals.Clear();
+        }
+
+        #endregion
+
+        #region Helpers
+
+        /// <summary>
+        /// Stages a removal by copying the matching triples out of the baseline into the removals
+        /// graph.
+        /// </summary>
+        /// <remarks>
+        /// Copying rather than re-serializing the value is deliberate: the staged triple has to be
+        /// term-identical to the baseline's, and stores do not agree on literal normalization —
+        /// Virtuoso 7 turns a plain literal into <c>xsd:string</c> and does not equate the two. A
+        /// server-side copy is immune to that, and is also how a real staging layer would record a
+        /// removal.
+        /// </remarks>
+        protected void StageRemoval(Uri subject, Property predicate)
+        {
+            var update = new SparqlUpdate(
+                "INSERT { GRAPH @removals { ?s ?p ?o } } " +
+                "WHERE { GRAPH @baseline { ?s ?p ?o . FILTER (?s = @subject && ?p = @predicate) } }")
+                .Bind("@removals", Removals)
+                .Bind("@baseline", Baseline)
+                .Bind("@subject", subject)
+                .Bind("@predicate", predicate.Uri);
+
+            Removals.ExecuteUpdate(update);
+        }
+
+        /// <summary>
+        /// Stages every triple of a subject for removal.
+        /// </summary>
+        protected void StageRemovalOfEverything(Uri subject)
+        {
+            var update = new SparqlUpdate(
+                "INSERT { GRAPH @removals { ?s ?p ?o } } " +
+                "WHERE { GRAPH @baseline { ?s ?p ?o . FILTER (?s = @subject) } }")
+                .Bind("@removals", Removals)
+                .Bind("@baseline", Baseline)
+                .Bind("@subject", subject);
+
+            Removals.ExecuteUpdate(update);
+        }
+
+        /// <summary>
+        /// Asserts whether a triple is visible through the view, without going through the mapped
+        /// API — so a failure points at the overlay rather than at resource materialization.
+        /// </summary>
+        protected bool VisibleThroughView(Uri subject, Property predicate)
+        {
+            return View.GetResource(subject).ListValues(predicate).Any();
+        }
+
+        protected bool PresentIn(IModel model, Uri subject, Property predicate)
+        {
+            var query = new SparqlQuery("ASK FROM @graph { @subject @predicate ?o . }")
+                .Bind("@graph", model)
+                .Bind("@subject", subject)
+                .Bind("@predicate", predicate.Uri);
+
+            return model.ExecuteQuery(query).GetAnwser();
+        }
+
+        /// <summary>
+        /// Creates a typed resource with a single string value in the baseline.
+        /// </summary>
+        protected MappingTestClass GivenBaselineResource(UriRef uri, string value)
+        {
+            var resource = Baseline.CreateResource<MappingTestClass>(uri);
+            resource.uniqueStringTest = value;
+            resource.Commit();
+
+            return resource;
+        }
+
+        /// <summary>
+        /// Creates an attribute-mapped resource in the baseline. The LINQ provider resolves
+        /// predicates from <c>[RdfProperty]</c>, which the <c>PropertyMapping</c>-style test classes
+        /// do not carry, so LINQ assertions use this object model instead.
+        /// </summary>
+        protected Agent GivenBaselineAgent(UriRef uri, string firstName)
+        {
+            var agent = Baseline.CreateResource<Agent>(uri);
+            agent.FirstName = firstName;
+            agent.Commit();
+
+            return agent;
+        }
+
+        #endregion
+
+        #region Acceptance criteria
+
+        [Test]
+        public virtual void RemovedTripleIsInvisibleThroughViewButRemainsInBaseline()
+        {
+            GivenBaselineResource(R1, "baseline value");
+
+            Assert.IsTrue(VisibleThroughView(R1, to.uniqueStringTest), "precondition: visible before staging");
+
+            StageRemoval(R1, to.uniqueStringTest);
+
+            Assert.IsFalse(VisibleThroughView(R1, to.uniqueStringTest), "removed triple must be invisible through the view");
+            Assert.IsTrue(PresentIn(Baseline, R1, to.uniqueStringTest), "the baseline must be untouched");
+        }
+
+        [Test]
+        public virtual void AddedTripleIsVisibleThroughViewButAbsentFromBaseline()
+        {
+            var resource = Additions.CreateResource<MappingTestClass>(R1);
+            resource.uniqueStringTest = "staged value";
+            resource.Commit();
+
+            Assert.IsTrue(VisibleThroughView(R1, to.uniqueStringTest), "added triple must be visible through the view");
+            Assert.IsFalse(PresentIn(Baseline, R1, to.uniqueStringTest), "the baseline must not have gained the triple");
+        }
+
+        [Test]
+        public virtual void AdditionWinsOverRemovalForTheSameTriple()
+        {
+            GivenBaselineResource(R1, "baseline value");
+
+            // Stage the exact baseline triple for removal, then stage it right back as an addition.
+            StageRemoval(R1, to.uniqueStringTest);
+
+            var update = new SparqlUpdate(
+                "INSERT { GRAPH @additions { ?s ?p ?o } } " +
+                "WHERE { GRAPH @removals { ?s ?p ?o } }")
+                .Bind("@additions", Additions)
+                .Bind("@removals", Removals);
+
+            Additions.ExecuteUpdate(update);
+
+            Assert.IsTrue(VisibleThroughView(R1, to.uniqueStringTest),
+                "a triple in both additions and removals must be visible: additions win");
+        }
+
+        #endregion
+
+        #region Mapped-object reads
+
+        [Test]
+        public virtual void GetResourceReflectsAStagedValueChange()
+        {
+            GivenBaselineResource(R1, "old");
+
+            StageRemoval(R1, to.uniqueStringTest);
+
+            var staged = Additions.CreateResource<MappingTestClass>(R1);
+            staged.uniqueStringTest = "new";
+            staged.Commit();
+
+            var seen = View.GetResource<MappingTestClass>(R1);
+
+            Assert.AreEqual("new", seen.uniqueStringTest, "the view must show the staged value, not the baseline's");
+            Assert.AreEqual("old", Baseline.GetResource<MappingTestClass>(R1).uniqueStringTest,
+                "the baseline must still hold the original value");
+        }
+
+        [Test]
+        public virtual void GetResourceReadsARemovedValueAsUnset()
+        {
+            GivenBaselineResource(R1, "baseline value");
+
+            StageRemoval(R1, to.uniqueStringTest);
+
+            var seen = View.GetResource<MappingTestClass>(R1);
+
+            Assert.IsNull(seen.uniqueStringTest, "a mapped property whose only value is staged for removal must read as unset");
+        }
+
+        [Test]
+        public virtual void ContainsResourceHonoursTheOverlay()
+        {
+            Assert.IsFalse(View.ContainsResource(R1));
+
+            GivenBaselineResource(R1, "baseline value");
+
+            Assert.IsTrue(View.ContainsResource(R1));
+
+            StageRemovalOfEverything(R1);
+
+            Assert.IsFalse(View.ContainsResource(R1), "a fully removed resource must not be contained in the view");
+            Assert.IsTrue(Baseline.ContainsResource(R1), "the baseline must still contain it");
+        }
+
+        [Test]
+        public virtual void IsEmptyHonoursTheOverlay()
+        {
+            Assert.IsTrue(View.IsEmpty);
+
+            GivenBaselineResource(R1, "baseline value");
+
+            Assert.IsFalse(View.IsEmpty);
+
+            StageRemovalOfEverything(R1);
+
+            Assert.IsTrue(View.IsEmpty, "a baseline whose every triple is staged for removal must read as empty");
+            Assert.IsFalse(Baseline.IsEmpty, "the baseline itself is not empty");
+        }
+
+        [Test]
+        public virtual void GetResourcesOfTypeHonoursTheOverlay()
+        {
+            GivenBaselineResource(R1, "one");
+            GivenBaselineResource(R2, "two");
+
+            Assert.AreEqual(2, View.GetResources<MappingTestClass>().Count());
+
+            StageRemovalOfEverything(R1);
+
+            var seen = View.GetResources<MappingTestClass>().ToList();
+
+            Assert.AreEqual(1, seen.Count, "a removed resource must not be enumerated");
+            Assert.AreEqual(R2, seen[0].Uri);
+        }
+
+        [Test]
+        public virtual void GetResourcesByUriHonoursTheOverlay()
+        {
+            GivenBaselineResource(R1, "one");
+            GivenBaselineResource(R2, "two");
+
+            StageRemoval(R1, to.uniqueStringTest);
+
+            var seen = View.GetResources(new Uri[] { R1, R2 }, typeof(MappingTestClass))
+                .Cast<MappingTestClass>()
+                .ToDictionary(r => r.Uri);
+
+            Assert.IsNull(seen[R1].uniqueStringTest, "the removed value must not come back");
+            Assert.AreEqual("two", seen[R2].uniqueStringTest);
+        }
+
+        #endregion
+
+        #region LINQ
+
+        [Test]
+        public virtual void LinqWhereDoesNotMatchARemovedValue()
+        {
+            GivenBaselineAgent(R1, "findme");
+
+            Assert.AreEqual(1, View.AsQueryable<Agent>().Count(a => a.FirstName == "findme"),
+                "precondition: matches before staging");
+
+            StageRemoval(R1, foaf.firstName);
+
+            // The selection-vs-materialization case: the value appears only in the WHERE clause, so
+            // it is the overlay on the *selection* pattern that has to subtract it. Without that,
+            // the resource would still be selected and only its triples would come back subtracted.
+            Assert.AreEqual(0, View.AsQueryable<Agent>().Count(a => a.FirstName == "findme"),
+                "a resource whose matching value is staged for removal must not be selected");
+        }
+
+        [Test]
+        public virtual void LinqWhereMatchesAStagedAddition()
+        {
+            var staged = Additions.CreateResource<Agent>(R1);
+            staged.FirstName = "findme";
+            staged.Commit();
+
+            var found = View.AsQueryable<Agent>().Where(a => a.FirstName == "findme").ToList();
+
+            Assert.AreEqual(1, found.Count, "a staged addition must be selectable");
+            Assert.AreEqual(R1, found[0].Uri);
+        }
+
+        #endregion
+
+        #region Refusals
+
+        [Test]
+        public virtual void CallerSuppliedSparqlIsRewrittenToHonourTheOverlay()
+        {
+            GivenBaselineResource(R1, "baseline value");
+            StageRemoval(R1, to.uniqueStringTest);
+
+            // A caller query is rewritten rather than refused, so the removal applies to it too.
+            var query = new SparqlQuery(
+                $"SELECT ?s WHERE {{ ?s <{to.uniqueStringTest.Uri}> ?o }}", declarePrefixes: false);
+
+            Assert.IsEmpty(View.GetBindings(query).ToList(),
+                "the staged removal must apply to a caller-supplied query as well");
+        }
+
+        [Test]
+        public virtual void CallerSuppliedSparqlThatCannotBeRewrittenThrows()
+        {
+            // A form the rewriter cannot handle must throw rather than answer without the overlay -
+            // silently returning triples staged for removal is the one failure this design excludes.
+            var path = new SparqlQuery(
+                $"SELECT ?s WHERE {{ ?s <{to.resourceTest.Uri}>/<{to.uniqueStringTest.Uri}> ?o }}",
+                declarePrefixes: false);
+
+            Assert.Throws<NotSupportedException>(() => View.ExecuteQuery(path));
+
+            var graphBlock = new SparqlQuery(
+                $"SELECT ?s WHERE {{ GRAPH <{Baseline.Uri}> {{ ?s ?p ?o }} }}", declarePrefixes: false);
+
+            Assert.Throws<NotSupportedException>(() => View.GetBindings(graphBlock).ToList());
+        }
+
+        [Test]
+        public virtual void InferenceEnabledThrows()
+        {
+            Assert.Throws<NotSupportedException>(() => View.GetResources<MappingTestClass>(inferenceEnabled: true).ToList());
+            Assert.Throws<NotSupportedException>(() => View.AsQueryable<MappingTestClass>(inferenceEnabled: true));
+        }
+
+        [Test]
+        public virtual void WritesThrow()
+        {
+            Assert.Throws<NotSupportedException>(() => View.CreateResource(R1));
+            Assert.Throws<NotSupportedException>(() => View.CreateResource<MappingTestClass>(R1));
+            Assert.Throws<NotSupportedException>(() => View.DeleteResource(R1));
+            Assert.Throws<NotSupportedException>(() => View.UpdateResource(new MappingTestClass(R1)));
+            Assert.Throws<NotSupportedException>(() => View.ExecuteUpdate(new SparqlUpdate("CLEAR GRAPH <urn:x>")));
+            Assert.Throws<NotSupportedException>(() => View.Clear());
+        }
+
+        [Test]
+        public virtual void OverlappingLayersAreRejected()
+        {
+            Assert.Throws<ArgumentException>(() => Store.CreateLayeredModel(Baseline.Uri, Baseline.Uri, Removals.Uri));
+            Assert.Throws<ArgumentException>(() => Store.CreateLayeredModel(Baseline.Uri, Additions.Uri, Additions.Uri));
+        }
+
+        #endregion
+
+        #region Regressions
+
+        [Test]
+        public virtual void LazyLoadedResourceHonoursTheOverlay()
+        {
+            var target = Baseline.CreateResource<ResourceMappingTestClass>(R2);
+            target.IntegerValue = 42;
+            target.Commit();
+
+            var source = Baseline.CreateResource<ResourceMappingTestClass>(R1);
+            source.Resource = target;
+            source.Commit();
+
+            StageRemoval(R2, to.intTest);
+
+            var seen = View.GetResource<ResourceMappingTestClass>(R1);
+
+            Assert.IsNotNull(seen.Resource, "the link itself is not staged for removal");
+            Assert.AreEqual(0, seen.Resource.IntegerValue,
+                "a lazily loaded linked resource must also be read through the overlay");
+            Assert.AreEqual(42, Baseline.GetResource<ResourceMappingTestClass>(R2).IntegerValue,
+                "the baseline must still hold the linked value");
+        }
+
+        #endregion
+    }
+}

--- a/Trinity/Model/ILayeredModel.cs
+++ b/Trinity/Model/ILayeredModel.cs
@@ -1,0 +1,86 @@
+// LICENSE:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// AUTHORS:
+//
+//  Moritz Eberl <moritz@semiodesk.com>
+//  Sebastian Faubel <sebastian@semiodesk.com>
+//
+// Copyright (c) Semiodesk GmbH 2026
+
+namespace Semiodesk.Trinity
+{
+    /// <summary>
+    /// A read-only view over three named graphs with working-copy semantics: a
+    /// <c>baseline</c> graph plus a pending change held as an <c>additions</c> and a
+    /// <c>removals</c> graph.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Reads through the view see <c>(baseline − removals) ∪ additions</c> — the baseline as
+    /// if the pending change had been applied, deletions included — while the baseline itself
+    /// stays untouched until the change is accepted or discarded. It is a git working tree
+    /// expressed in RDF.
+    /// </para>
+    /// <para>
+    /// A triple present in both <see cref="Additions"/> and <see cref="Removals"/> is
+    /// <b>visible</b>: additions win. Staging an addition always makes it readable, which is
+    /// what makes an edit (remove the old value, add the new one) behave the way callers expect.
+    /// </para>
+    /// <para>
+    /// This is deliberately <b>not</b> an <see cref="IModelGroup"/>. A group is an
+    /// <c>ISet&lt;IModel&gt;</c> whose members are interchangeable and merely unioned; the three
+    /// graphs here have distinct roles, so set membership has no meaning for them. Keeping the
+    /// types apart also stops the existing <c>is IModelGroup</c> code paths — which can only
+    /// express union — from mistaking a layered view for one.
+    /// </para>
+    /// <para>
+    /// The view is <b>read-only</b> in this release: every mutating member of
+    /// <see cref="IModel"/> throws <see cref="System.NotSupportedException"/>, exactly as
+    /// <c>ModelGroup</c> does. Stage a change by writing to <see cref="Additions"/> and
+    /// <see cref="Removals"/>, which are ordinary models.
+    /// </para>
+    /// <para>
+    /// Only the reads Trinity itself formulates can honour the overlay, because subtraction has
+    /// to live inside the graph pattern rather than the dataset clause. Caller-supplied SPARQL
+    /// and inference-enabled reads therefore <b>throw</b> rather than quietly returning
+    /// unsubtracted triples. See <c>doc/adr/0041-layered-read-views.md</c>.
+    /// </para>
+    /// </remarks>
+    public interface ILayeredModel : IModel
+    {
+        /// <summary>
+        /// The unchanged graph the view reads through. Never written to by the view.
+        /// </summary>
+        IModel Baseline { get; }
+
+        /// <summary>
+        /// Triples staged for addition. Visible through the view, and they win over
+        /// <see cref="Removals"/>.
+        /// </summary>
+        IModel Additions { get; }
+
+        /// <summary>
+        /// Triples staged for removal. Invisible through the view while remaining present in
+        /// <see cref="Baseline"/>.
+        /// </summary>
+        IModel Removals { get; }
+    }
+}

--- a/Trinity/Model/LayeredModel.cs
+++ b/Trinity/Model/LayeredModel.cs
@@ -1,0 +1,669 @@
+// LICENSE:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// AUTHORS:
+//
+//  Moritz Eberl <moritz@semiodesk.com>
+//  Sebastian Faubel <sebastian@semiodesk.com>
+//
+// Copyright (c) Semiodesk GmbH 2026
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Data;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using VDS.RDF;
+
+namespace Semiodesk.Trinity
+{
+    /// <summary>
+    /// Implementation of <see cref="ILayeredModel"/>.
+    /// </summary>
+    /// <remarks>
+    /// Every read this class formulates is composed from <see cref="LayeredModelSparql"/>, so the
+    /// overlay reaches the graph pattern of each one. Reads it cannot rewrite — caller-supplied
+    /// SPARQL, and anything with inferencing on — throw instead of returning unsubtracted data.
+    /// </remarks>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class LayeredModel : ILayeredModel
+    {
+        #region Members
+
+        private readonly IStore _store;
+
+        private readonly MethodInfo _getResourceMethod;
+
+        /// <summary>
+        /// Cached <c>FROM NAMED</c> clause. The three graphs are fixed for the lifetime of the
+        /// view, so unlike a model group's dataset clause this never needs invalidating.
+        /// </summary>
+        private readonly string _datasetClause;
+
+        /// <inheritdoc />
+        public IModel Baseline { get; }
+
+        /// <inheritdoc />
+        public IModel Additions { get; }
+
+        /// <inheritdoc />
+        public IModel Removals { get; }
+
+        /// <summary>
+        /// All unmapped properties will be ignored for update and thus deleted.
+        /// </summary>
+        /// <remarks>
+        /// Settable for interface compatibility only — this view never writes.
+        /// </remarks>
+        public bool IgnoreUnmappedProperties { get; set; } = false;
+
+        /// <summary>
+        /// A layered view spans three graphs, so it has no URI of its own — as with a model group.
+        /// </summary>
+        public UriRef Uri => null;
+
+        /// <summary>
+        /// Tests whether the view is empty, i.e. whether the effective graph holds no triple.
+        /// </summary>
+        /// <remarks>
+        /// A baseline whose every triple is staged for removal reads as empty here while the
+        /// baseline graph itself is not.
+        /// </remarks>
+        public bool IsEmpty
+        {
+            get
+            {
+                ISparqlQuery query = CreateOverlayQuery(
+                    "ASK " + _datasetClause + "{ " + Overlay("?s", "?p", "?o") + " }");
+
+                return !ExecuteOverlayQuery(query, null).GetAnwser();
+            }
+        }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Creates a layered view over three models of the same store.
+        /// </summary>
+        /// <param name="store">The store holding all three graphs.</param>
+        /// <param name="baseline">The unchanged graph read through the view.</param>
+        /// <param name="additions">Triples staged for addition.</param>
+        /// <param name="removals">Triples staged for removal.</param>
+        /// <remarks>
+        /// Internal by design: use <c>IStore.CreateLayeredModel(...)</c>. All three graphs must live
+        /// in <paramref name="store"/>, because the overlay is one SPARQL query over one dataset -
+        /// see the remarks on <c>StoreExtensions.CreateLayeredModel</c>. Routing construction
+        /// through the factory, which resolves all three URIs against a single store, makes a
+        /// cross-store view unrepresentable rather than merely discouraged.
+        /// </remarks>
+        /// <exception cref="ArgumentException">
+        /// Thrown if any two of the three models are the same graph. Overlapping layers would make
+        /// the view's result depend on evaluation order rather than on the staged change.
+        /// </exception>
+        internal LayeredModel(IStore store, IModel baseline, IModel additions, IModel removals)
+        {
+            _store = store ?? throw new ArgumentNullException(nameof(store));
+            Baseline = baseline ?? throw new ArgumentNullException(nameof(baseline));
+            Additions = additions ?? throw new ArgumentNullException(nameof(additions));
+            Removals = removals ?? throw new ArgumentNullException(nameof(removals));
+
+            RequireDistinct(baseline, additions, nameof(baseline), nameof(additions));
+            RequireDistinct(baseline, removals, nameof(baseline), nameof(removals));
+            RequireDistinct(additions, removals, nameof(additions), nameof(removals));
+
+            _datasetClause = LayeredModelSparql.NamedDatasetClause(this);
+
+            foreach (MethodInfo methodInfo in GetType().GetMethods())
+            {
+                if (methodInfo.Name == "GetResource" && methodInfo.IsGenericMethod)
+                {
+                    _getResourceMethod = methodInfo;
+                    break;
+                }
+            }
+        }
+
+        private static void RequireDistinct(IModel a, IModel b, string nameA, string nameB)
+        {
+            if (a.Uri == null || b.Uri == null)
+            {
+                throw new ArgumentException("A layered model requires three models that each name a graph.");
+            }
+
+            if (a.Uri.Equals(b.Uri))
+            {
+                throw new ArgumentException(
+                    $"The {nameA} and {nameB} models of a layered model must be different graphs, both are <{a.Uri}>.");
+            }
+        }
+
+        #endregion
+
+        #region Overlay query construction
+
+        /// <summary>
+        /// Wraps one triple pattern in the overlay.
+        /// </summary>
+        private string Overlay(string subject, string predicate, string @object)
+        {
+            return LayeredModelSparql.Overlay(this, subject, predicate, @object);
+        }
+
+        /// <summary>
+        /// Builds a query and marks it as having the overlay already applied, which is what
+        /// distinguishes Trinity's own overlay-aware reads from a caller's SPARQL.
+        /// </summary>
+        private static ISparqlQuery CreateOverlayQuery(string queryString)
+        {
+            return new SparqlQuery(queryString, declarePrefixes: false) { IsOverlayApplied = true };
+        }
+
+        /// <summary>
+        /// Runs a query this class built. Bypasses the guard in
+        /// <see cref="ExecuteQuery(ISparqlQuery, bool, ITransaction)"/> because the overlay is
+        /// already in the query's graph patterns.
+        /// </summary>
+        private ISparqlQueryResult ExecuteOverlayQuery(ISparqlQuery query, ITransaction transaction)
+        {
+            query.Model = this;
+            query.IsInferenceEnabled = false;
+
+            return _store.ExecuteQuery(query, transaction);
+        }
+
+        /// <summary>
+        /// The query every whole-resource read uses: all triples of the given subjects, resolved
+        /// against the effective graph.
+        /// </summary>
+        /// <remarks>
+        /// The subjects are bound with <c>VALUES</c> ahead of the overlay so the read is an
+        /// indexed probe on every backend, and the projection stays <c>?s ?p ?o</c> in that order
+        /// so <c>ISparqlQuery.ProvidesStatements()</c> — a token-level heuristic that demands
+        /// exactly three same-ordered variables — keeps returning true. Without that, resource
+        /// materialization refuses the query outright.
+        /// </remarks>
+        private ISparqlQuery CreateResourceQuery(IEnumerable<Uri> uris)
+        {
+            var queryString = new StringBuilder();
+
+            queryString.Append("SELECT DISTINCT ?s ?p ?o ");
+            queryString.Append(_datasetClause);
+            queryString.Append("WHERE { ");
+            queryString.Append(LayeredModelSparql.BindSubjects("?s", uris));
+            queryString.Append(Overlay("?s", "?p", "?o"));
+            queryString.Append(" }");
+
+            return CreateOverlayQuery(queryString.ToString());
+        }
+
+        /// <summary>
+        /// Rejects a subject that cannot appear in a SPARQL query.
+        /// </summary>
+        private static void RequireQueryableSubject(Uri uri)
+        {
+            if (uri == null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            if (uri is UriRef uriRef && uriRef.IsBlankId)
+            {
+                throw new ArgumentException("Blank nodes are not supported as query subjects in SPARQL 1.1");
+            }
+        }
+
+        #endregion
+
+        #region Read methods
+
+        /// <summary>
+        /// Indicates whether a resource is visible through the view.
+        /// </summary>
+        /// <remarks>
+        /// False for a resource whose every triple is staged for removal, even though the baseline
+        /// still holds them.
+        /// </remarks>
+        /// <param name="uri">A Uniform Resource Identifier.</param>
+        /// <param name="transaction">Transaction associated with this action.</param>
+        /// <returns><c>true</c> if the resource is part of the effective graph.</returns>
+        public bool ContainsResource(Uri uri, ITransaction transaction = null)
+        {
+            RequireQueryableSubject(uri);
+
+            ISparqlQuery query = CreateOverlayQuery("ASK " + _datasetClause + "{ " +
+                Overlay(SparqlSerializer.SerializeUri(uri), "?p", "?o") + " }");
+
+            return ExecuteOverlayQuery(query, transaction).GetAnwser();
+        }
+
+        /// <inheritdoc cref="ContainsResource(Uri, ITransaction)" />
+        public bool ContainsResource(IResource resource, ITransaction transaction = null)
+        {
+            return ContainsResource(resource.Uri, transaction);
+        }
+
+        /// <summary>
+        /// Retrieves a resource as it appears through the view.
+        /// </summary>
+        /// <param name="uri">A Uniform Resource Identifier.</param>
+        /// <param name="transaction">Transaction associated with this action.</param>
+        /// <returns>A resource with all effective properties.</returns>
+        public IResource GetResource(Uri uri, ITransaction transaction = null)
+        {
+            RequireQueryableSubject(uri);
+
+            ISparqlQueryResult result = ExecuteOverlayQuery(CreateResourceQuery(new[] { uri }), transaction);
+
+            Resource resource = result.GetResources().FirstOrDefault();
+
+            if (resource == null)
+            {
+                throw new ResourceNotFoundException(uri);
+            }
+
+            Attach(resource);
+
+            return resource;
+        }
+
+        /// <inheritdoc cref="GetResource(Uri, ITransaction)" />
+        public IResource GetResource(IResource resource, ITransaction transaction = null)
+        {
+            return GetResource(resource.Uri, transaction);
+        }
+
+        /// <summary>
+        /// Retrieves a resource of the given type as it appears through the view.
+        /// </summary>
+        /// <typeparam name="T">The type of the resource.</typeparam>
+        /// <param name="uri">A Uniform Resource Identifier.</param>
+        /// <param name="transaction">Transaction associated with this action.</param>
+        /// <returns>A resource with all effective properties.</returns>
+        public T GetResource<T>(Uri uri, ITransaction transaction = null) where T : Resource
+        {
+            RequireQueryableSubject(uri);
+
+            ISparqlQueryResult result = ExecuteOverlayQuery(CreateResourceQuery(new[] { uri }), transaction);
+
+            T resource = result.GetResources<T>().FirstOrDefault();
+
+            if (resource == null)
+            {
+                throw new ResourceNotFoundException(uri);
+            }
+
+            Attach(resource);
+
+            return resource;
+        }
+
+        /// <inheritdoc cref="GetResource{T}(Uri, ITransaction)" />
+        public T GetResource<T>(IResource resource, ITransaction transaction = null) where T : Resource
+        {
+            return GetResource<T>(resource.Uri, transaction);
+        }
+
+        /// <summary>
+        /// Retrieves a resource of the given runtime type as it appears through the view.
+        /// </summary>
+        /// <param name="uri">A Uniform Resource Identifier.</param>
+        /// <param name="type">The type the resource should have.</param>
+        /// <param name="transaction">Transaction associated with this action.</param>
+        /// <returns>A resource with all effective properties.</returns>
+        public object GetResource(Uri uri, Type type, ITransaction transaction = null)
+        {
+            if (_getResourceMethod == null)
+            {
+                throw new InvalidOperationException("No handle to the generic method T GetResource<T>(Uri)");
+            }
+
+            if (!typeof(IResource).IsAssignableFrom(type))
+            {
+                throw new ArgumentException($"The given type {type} does not implement the IResource interface.");
+            }
+
+            MethodInfo getResource = _getResourceMethod.MakeGenericMethod(type);
+
+            return getResource.Invoke(this, new object[] { uri, transaction });
+        }
+
+        /// <summary>
+        /// Retrieves several resources of the given type as they appear through the view.
+        /// </summary>
+        /// <param name="uris">The Uniform Resource Identifiers to retrieve.</param>
+        /// <param name="type">The type the resources should have.</param>
+        /// <param name="transaction">Transaction associated with this action.</param>
+        /// <returns>An enumeration of resources with all effective properties.</returns>
+        public IEnumerable<object> GetResources(IEnumerable<Uri> uris, Type type, ITransaction transaction = null)
+        {
+            if (!typeof(IResource).IsAssignableFrom(type))
+            {
+                throw new ArgumentException($"Error: The given type {type} does not implement the IResource interface.");
+            }
+
+            List<Uri> subjects = (uris ?? Enumerable.Empty<Uri>()).ToList();
+
+            if (subjects.Count == 0)
+            {
+                return Enumerable.Empty<object>();
+            }
+
+            foreach (Uri uri in subjects)
+            {
+                RequireQueryableSubject(uri);
+            }
+
+            ISparqlQueryResult result = ExecuteOverlayQuery(CreateResourceQuery(subjects), transaction);
+
+            return Materialize(result.GetResources(type));
+        }
+
+        /// <summary>
+        /// Returns every resource of the given type that is visible through the view.
+        /// </summary>
+        /// <remarks>
+        /// The type constraints are emitted <b>before</b> the wildcard triple pattern. Order is
+        /// not cosmetic here: an engine that cannot reorder joins across the overlay's
+        /// <c>UNION</c> evaluates the patterns as written, and putting the unselective wildcard
+        /// first makes it materialize the whole effective graph before applying any constraint.
+        /// </remarks>
+        /// <typeparam name="T">The type of the resources.</typeparam>
+        /// <param name="inferenceEnabled">Must be <c>false</c>; inferencing is not supported.</param>
+        /// <param name="transaction">Transaction associated with the action.</param>
+        /// <returns>An enumeration of resources visible through the view.</returns>
+        public IEnumerable<T> GetResources<T>(bool inferenceEnabled = false, ITransaction transaction = null) where T : Resource
+        {
+            RequireNoInferencing(inferenceEnabled);
+
+            var instance = (T)Activator.CreateInstance(typeof(T), new UriRef("urn:"));
+
+            var queryString = new StringBuilder();
+
+            queryString.Append("SELECT DISTINCT ?s ?p ?o ");
+            queryString.Append(_datasetClause);
+            queryString.Append("WHERE { ");
+
+            foreach (Class type in instance.GetTypes())
+            {
+                queryString.Append(Overlay("?s", "a", SparqlSerializer.SerializeUri(type.Uri)));
+                queryString.Append(' ');
+            }
+
+            queryString.Append(Overlay("?s", "?p", "?o"));
+            queryString.Append(" }");
+
+            ISparqlQueryResult result = ExecuteOverlayQuery(
+                CreateOverlayQuery(queryString.ToString()), transaction);
+
+            return Materialize(result.GetResources<T>());
+        }
+
+        /// <summary>
+        /// Returns a LINQ query source over the view.
+        /// </summary>
+        /// <remarks>
+        /// Every triple pattern the provider emits is wrapped in the overlay, so a <c>Where</c>
+        /// clause matches against the effective graph rather than the raw baseline — a resource
+        /// whose only matching value is staged for removal does not match.
+        /// </remarks>
+        /// <typeparam name="T">The type of the resources.</typeparam>
+        /// <param name="inferenceEnabled">Must be <c>false</c>; inferencing is not supported.</param>
+        public IQueryable<T> AsQueryable<T>(bool inferenceEnabled = false) where T : Resource
+        {
+            RequireNoInferencing(inferenceEnabled);
+
+            return new Query.Sparql.TrinityQueryable<T>(new Query.Sparql.SparqlQueryProvider(this, false));
+        }
+
+        /// <summary>
+        /// Attaches a freshly read resource to this view and marks it read-only.
+        /// </summary>
+        private void Attach(Resource resource)
+        {
+            resource.IsNew = false;
+            resource.IsSynchronized = true;
+            resource.IsReadOnly = true;
+            resource.SetModel(this);
+        }
+
+        private IEnumerable<T> Materialize<T>(IEnumerable<T> resources) where T : Resource
+        {
+            if (resources == null)
+            {
+                yield break;
+            }
+
+            foreach (T resource in resources)
+            {
+                // A missing rdf:type yields a null entry; see the same guard in ModelGroup.
+                if (resource == null)
+                {
+                    continue;
+                }
+
+                Attach(resource);
+
+                yield return resource;
+            }
+        }
+
+        private IEnumerable<object> Materialize(IEnumerable<Resource> resources)
+        {
+            return Materialize<Resource>(resources).Cast<object>();
+        }
+
+        #endregion
+
+        #region Query execution: caller queries are rewritten, or refused
+
+        /// <summary>
+        /// Runs a query against the view, rewriting it so every triple pattern resolves against the
+        /// effective graph.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Queries Trinity built itself already carry the overlay and run as they are. A
+        /// caller-supplied query is rewritten by <see cref="OverlayQueryRewriter"/>, which works on
+        /// the parse tree and accepts only the forms it can prove it handles. A form it cannot —
+        /// property paths, explicit <c>GRAPH</c> blocks, <c>SERVICE</c>, <c>CONSTRUCT</c>,
+        /// <c>DESCRIBE</c>, <c>FILTER EXISTS</c> — throws with the reason.
+        /// </para>
+        /// <para>
+        /// Refusing matters because running such a query unchanged is wrong in two different ways
+        /// depending on its shape, and neither announces itself: a pattern against the default graph
+        /// returns nothing at all (the view names its graphs with <c>FROM NAMED</c>, leaving the
+        /// default graph empty), while a pattern naming a graph returns triples staged for removal.
+        /// </para>
+        /// </remarks>
+        /// <exception cref="NotSupportedException">
+        /// Thrown if the query cannot be rewritten faithfully, or if inferencing is requested.
+        /// </exception>
+        public ISparqlQueryResult ExecuteQuery(ISparqlQuery query, bool inferenceEnabled = false, ITransaction transaction = null)
+        {
+            RequireNoInferencing(inferenceEnabled);
+
+            if (query == null)
+            {
+                throw new ArgumentNullException(nameof(query));
+            }
+
+            if (query is SparqlQuery sparqlQuery && sparqlQuery.IsOverlayApplied)
+            {
+                return ExecuteOverlayQuery(query, transaction);
+            }
+
+            // ToString() substitutes the @parameters, which the strict SPARQL parser the rewriter
+            // uses would otherwise reject. The caller's query object is left untouched.
+            ISparqlQuery rewritten = CreateOverlayQuery(OverlayQueryRewriter.Rewrite(this, query.ToString()));
+
+            return ExecuteOverlayQuery(rewritten, transaction);
+        }
+
+        /// <summary>
+        /// Materializes the resources selected by a query, rewritten to honour the overlay. See
+        /// <see cref="ExecuteQuery(ISparqlQuery, bool, ITransaction)" /> for which forms are accepted.
+        /// </summary>
+        public IEnumerable<Resource> GetResources(ISparqlQuery query, bool inferenceEnabled = false, ITransaction transaction = null)
+        {
+            return Materialize<Resource>(ExecuteQuery(query, inferenceEnabled, transaction).GetResources<Resource>());
+        }
+
+        /// <summary>
+        /// Materializes the resources selected by a query, rewritten to honour the overlay. See
+        /// <see cref="ExecuteQuery(ISparqlQuery, bool, ITransaction)" /> for which forms are accepted.
+        /// </summary>
+        /// <remarks>
+        /// This is also the entry point the LINQ provider materializes through; the queries it builds
+        /// already carry the overlay and pass straight through.
+        /// </remarks>
+        public IEnumerable<T> GetResources<T>(ISparqlQuery query, bool inferenceEnabled = false, ITransaction transaction = null) where T : Resource
+        {
+            return Materialize(ExecuteQuery(query, inferenceEnabled, transaction).GetResources<T>());
+        }
+
+        /// <summary>
+        /// Returns the bindings of a query, rewritten to honour the overlay. See
+        /// <see cref="ExecuteQuery(ISparqlQuery, bool, ITransaction)" /> for which forms are accepted.
+        /// </summary>
+        public IEnumerable<BindingSet> GetBindings(ISparqlQuery query, bool inferenceEnabled = false, ITransaction transaction = null)
+        {
+            return ExecuteQuery(query, inferenceEnabled, transaction).GetBindings();
+        }
+
+        /// <summary>
+        /// Refuses an inference-enabled read.
+        /// </summary>
+        /// <remarks>
+        /// Every store's inference path defeats the overlay. GraphDB rebuilds the query's dataset
+        /// as a plain model group, which is union-only; Virtuoso answers inference-enabled
+        /// resource reads with a bare <c>DESCRIBE</c>, which cannot carry a guard. Beyond the
+        /// mechanics, entailment over a subtracted graph is not something any of the store
+        /// reasoners defines. So this is refused rather than approximated.
+        /// </remarks>
+        internal static void RequireNoInferencing(bool inferenceEnabled)
+        {
+            if (inferenceEnabled)
+            {
+                throw new NotSupportedException(
+                    "Inferencing is not supported on a layered model. The stores' inference paths cannot " +
+                    "carry the baseline/additions/removals overlay — GraphDB rebuilds the dataset as a " +
+                    "union and Virtuoso falls back to a bare DESCRIBE — so the result would silently " +
+                    "include triples staged for removal.");
+            }
+        }
+
+        #endregion
+
+        #region Not supported: the view is read-only
+
+        private static NotSupportedException ReadOnly()
+        {
+            return new NotSupportedException(
+                "Layered models are read-only. Stage a change by writing to the Additions and Removals " +
+                "models, which are ordinary models, and the view will read the result.");
+        }
+
+        /// <summary>Not supported. Layered models are read-only.</summary>
+        public IResource AddResource(IResource resource, ITransaction transaction = null) => throw ReadOnly();
+
+        /// <summary>Not supported. Layered models are read-only.</summary>
+        public T AddResource<T>(T resource, ITransaction transaction = null) where T : Resource => throw ReadOnly();
+
+        /// <summary>Not supported. Layered models are read-only.</summary>
+        public IResource CreateResource(string format = "urn:uuid:{0}", ITransaction transaction = null) => throw ReadOnly();
+
+        /// <summary>Not supported. Layered models are read-only.</summary>
+        public IResource CreateResource(Uri uri, ITransaction transaction = null) => throw ReadOnly();
+
+        /// <summary>Not supported. Layered models are read-only.</summary>
+        public T CreateResource<T>(string format = "urn:uuid:{0}", ITransaction transaction = null) where T : Resource => throw ReadOnly();
+
+        /// <summary>Not supported. Layered models are read-only.</summary>
+        public T CreateResource<T>(Uri uri, ITransaction transaction = null) where T : Resource => throw ReadOnly();
+
+        /// <summary>Not supported. Layered models are read-only.</summary>
+        public object CreateResource(Type type, string format = "urn:uuid:{0}", ITransaction transaction = null) => throw ReadOnly();
+
+        /// <summary>Not supported. Layered models are read-only.</summary>
+        public object CreateResource(Uri uri, Type t, ITransaction transaction = null) => throw ReadOnly();
+
+        /// <summary>Not supported. Layered models are read-only.</summary>
+        public void DeleteResource(Uri uri, ITransaction transaction = null) => throw ReadOnly();
+
+        /// <summary>Not supported. Layered models are read-only.</summary>
+        public void DeleteResource(IResource resource, ITransaction transaction = null) => throw ReadOnly();
+
+        /// <summary>Not supported. Layered models are read-only.</summary>
+        public void DeleteResources(IEnumerable<Uri> uris, ITransaction transaction = null) => throw ReadOnly();
+
+        /// <summary>Not supported. Layered models are read-only.</summary>
+        public void DeleteResources(IEnumerable<IResource> resources, ITransaction transaction = null) => throw ReadOnly();
+
+        /// <summary>Not supported. Layered models are read-only.</summary>
+        public void DeleteResources(ITransaction transaction = null, params IResource[] resources) => throw ReadOnly();
+
+        /// <summary>Not supported. Layered models are read-only.</summary>
+        public void UpdateResource(Resource resource, ITransaction transaction = null) => throw ReadOnly();
+
+        /// <summary>Not supported. Layered models are read-only.</summary>
+        public void UpdateResources(IEnumerable<Resource> resources, ITransaction transaction = null) => throw ReadOnly();
+
+        /// <summary>Not supported. Layered models are read-only.</summary>
+        public void UpdateResources(ITransaction transaction = null, params Resource[] resources) => throw ReadOnly();
+
+        /// <summary>Not supported. Layered models are read-only.</summary>
+        public void ExecuteUpdate(ISparqlUpdate update, ITransaction transaction = null) => throw ReadOnly();
+
+        /// <summary>Not supported. Layered models are read-only.</summary>
+        public void Clear() => throw ReadOnly();
+
+        /// <summary>Not supported. Layered models are read-only.</summary>
+        public bool Read(Uri url, RdfSerializationFormat format, bool update) => throw ReadOnly();
+
+        /// <summary>Not supported. Layered models are read-only.</summary>
+        public bool Read(Stream stream, RdfSerializationFormat format, bool update) => throw ReadOnly();
+
+        /// <summary>Not supported. Layered models are read-only.</summary>
+        public bool Read(string content, RdfSerializationFormat format, bool update) => throw ReadOnly();
+
+        /// <summary>
+        /// Not supported. Serializing the view would mean materializing the effective graph, which
+        /// is a different operation from writing a model out; write the layer models instead.
+        /// </summary>
+        public void Write(Stream stream, RdfSerializationFormat format, INamespaceMap namespaces = null, Uri baseUri = null, bool leaveOpen = false) => throw ReadOnly();
+
+        /// <inheritdoc cref="Write(Stream, RdfSerializationFormat, INamespaceMap, Uri, bool)" />
+        public void Write(Stream stream, IRdfWriter formatWriter, bool leaveOpen = false) => throw ReadOnly();
+
+        /// <summary>
+        /// Not supported. A layered view spans three graphs and never writes, so there is nothing
+        /// for a transaction to scope.
+        /// </summary>
+        public ITransaction BeginTransaction(IsolationLevel isolationLevel) => throw ReadOnly();
+
+        #endregion
+    }
+}

--- a/Trinity/Model/Model.cs
+++ b/Trinity/Model/Model.cs
@@ -47,6 +47,15 @@ namespace Semiodesk.Trinity
         // The backing RDF store.
         private IStore _store;
 
+        /// <summary>
+        /// The store this model reads and writes. Used to reject compositions - such as a layered
+        /// model - that can only be evaluated within a single store's dataset.
+        /// </summary>
+        internal IStore Store
+        {
+            get { return _store; }
+        }
+
         // A handle to the generic version of the GetResource method which is being used
         // for implementing the GetResource(Uri, Type) method that supports runtime type specification.
         private MethodInfo _getResourceMethod;

--- a/Trinity/Query/LayeredModelSparql.cs
+++ b/Trinity/Query/LayeredModelSparql.cs
@@ -83,13 +83,58 @@ namespace Semiodesk.Trinity
             }
 
             string triple = string.Concat(subject, " ", predicate, " ", @object);
+            bool hasVariable = IsVariable(subject) || IsVariable(predicate) || IsVariable(@object);
 
-            string guard = IsVariable(subject) || IsVariable(predicate) || IsVariable(@object)
+            // The effective triple is in the baseline and not staged for removal...
+            string baselineBranch = string.Format("{{ GRAPH {0} {{ {1} }} {2} }}",
+                Graph(model.Baseline), triple, Guard(model, triple, hasVariable));
+
+            // ...or it is staged for addition and the baseline branch did not already yield it.
+            // Without that second condition the two branches overlap, and SPARQL UNION is a bag
+            // union: a triple present in both the baseline and the additions would produce two
+            // solutions where the view promises a set. Re-adding a triple that is already there is
+            // exactly what "additions win" invites, so the overlap is the common case, not a corner
+            // one - and it would show up as inflated COUNTs and duplicated rows, silently.
+            string additionsBranch = string.Format(
+                "{{ GRAPH {0} {{ {1} }} FILTER NOT EXISTS {{ GRAPH {2} {{ {1} }} {3} }} }}",
+                Graph(model.Additions), triple, Graph(model.Baseline),
+                GroundGuard(model, triple));
+
+            return "{ " + baselineBranch + " UNION " + additionsBranch + " }";
+        }
+
+        /// <summary>
+        /// The removals guard for the baseline branch.
+        /// </summary>
+        /// <remarks>
+        /// <c>MINUS</c> where the pattern binds a variable: engines evaluate it as an anti-join rather
+        /// than a per-row probe, which is the difference between 1.5x and 18x on an unselective scan.
+        /// But SPARQL <c>MINUS</c> removes nothing when the two sides share no variables, and a fully
+        /// ground pattern has none - so there it would <b>silently fail to subtract</b> (verified:
+        /// dotNetRDF and GraphDB both return the removed triple; Virtuoso happens not to). A ground
+        /// pattern is a single existence check, so <c>FILTER NOT EXISTS</c> costs nothing there and is
+        /// the only correct choice.
+        /// </remarks>
+        private static string Guard(ILayeredModel model, string triple, bool hasVariable)
+        {
+            return hasVariable
                 ? string.Format("MINUS {{ GRAPH {0} {{ {1} }} }}", Graph(model.Removals), triple)
                 : string.Format("FILTER NOT EXISTS {{ GRAPH {0} {{ {1} }} }}", Graph(model.Removals), triple);
+        }
 
-            return string.Format("{{ {{ GRAPH {0} {{ {1} }} {2} }} UNION {{ GRAPH {3} {{ {1} }} }} }}",
-                Graph(model.Baseline), triple, guard, Graph(model.Additions));
+        /// <summary>
+        /// The removals guard as used inside a <c>NOT EXISTS</c>, where <c>MINUS</c> is never safe.
+        /// </summary>
+        /// <remarks>
+        /// Nested inside <c>NOT EXISTS</c> the pattern is being tested for existence rather than
+        /// joined, so a <c>MINUS</c> whose sides share no variables would remove nothing and invert the
+        /// answer for a triple that is in the baseline, the removals and the additions at once.
+        /// <c>FILTER NOT EXISTS</c> is used unconditionally, and costs little because the additions
+        /// branch yields few rows to test.
+        /// </remarks>
+        private static string GroundGuard(ILayeredModel model, string triple)
+        {
+            return string.Format("FILTER NOT EXISTS {{ GRAPH {0} {{ {1} }} }}", Graph(model.Removals), triple);
         }
 
         /// <summary>

--- a/Trinity/Query/LayeredModelSparql.cs
+++ b/Trinity/Query/LayeredModelSparql.cs
@@ -1,0 +1,157 @@
+// LICENSE:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// AUTHORS:
+//
+//  Moritz Eberl <moritz@semiodesk.com>
+//  Sebastian Faubel <sebastian@semiodesk.com>
+//
+// Copyright (c) Semiodesk GmbH 2026
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Semiodesk.Trinity
+{
+    /// <summary>
+    /// Builds the SPARQL fragments that give an <see cref="ILayeredModel"/> its
+    /// <c>(baseline − removals) ∪ additions</c> semantics. Single source of truth: every read
+    /// path that honours the overlay composes its query from these, so the semantics cannot
+    /// drift between the hand-written templates and the LINQ writer.
+    /// </summary>
+    /// <remarks>
+    /// Subtraction cannot be expressed in a dataset clause — <c>FROM</c> is set union and SPARQL
+    /// has no inverse — so it has to sit in the graph pattern. Every triple pattern is therefore
+    /// replaced by <see cref="Overlay"/>, which resolves that one pattern against the effective
+    /// graph.
+    /// <para>
+    /// The three rules below are not micro-optimisations; each was measured, and getting one
+    /// wrong is either a silent wrong answer or a four-orders-of-magnitude regression. See
+    /// <c>doc/adr/0041-layered-read-views.md</c> for the numbers.
+    /// </para>
+    /// </remarks>
+    internal static class LayeredModelSparql
+    {
+        /// <summary>
+        /// Wraps one triple pattern so it resolves against the effective graph rather than a
+        /// single named graph.
+        /// </summary>
+        /// <remarks>
+        /// Emits
+        /// <c>{ { GRAPH baseline { T } &lt;guard&gt; } UNION { GRAPH additions { T } } }</c>.
+        /// The guard applies only to the baseline branch, which is what makes additions win over
+        /// removals.
+        /// <para>
+        /// <b>The guard is chosen by whether the pattern binds anything.</b> With at least one
+        /// variable, <c>MINUS</c> is used: engines evaluate it as an anti-join instead of a
+        /// per-row nested-loop probe, which is the difference between 1.5x and 18x on an
+        /// unselective scan. But SPARQL <c>MINUS</c> removes nothing when the two sides share no
+        /// variables, and a fully ground pattern has none — so there it would <b>silently fail to
+        /// subtract</b> (verified: dotNetRDF and GraphDB both return the removed triple; Virtuoso
+        /// happens not to). A ground pattern is a single existence check, so
+        /// <c>FILTER NOT EXISTS</c> costs nothing there and is the only correct choice.
+        /// </para>
+        /// </remarks>
+        /// <param name="model">The layered model supplying the three graph URIs.</param>
+        /// <param name="subject">Serialized subject term — a variable (<c>?s</c>) or an RDF term.</param>
+        /// <param name="predicate">Serialized predicate term.</param>
+        /// <param name="object">Serialized object term.</param>
+        /// <returns>A group graph pattern, braces included.</returns>
+        internal static string Overlay(ILayeredModel model, string subject, string predicate, string @object)
+        {
+            if (model == null)
+            {
+                throw new ArgumentNullException(nameof(model));
+            }
+
+            string triple = string.Concat(subject, " ", predicate, " ", @object);
+
+            string guard = IsVariable(subject) || IsVariable(predicate) || IsVariable(@object)
+                ? string.Format("MINUS {{ GRAPH {0} {{ {1} }} }}", Graph(model.Removals), triple)
+                : string.Format("FILTER NOT EXISTS {{ GRAPH {0} {{ {1} }} }}", Graph(model.Removals), triple);
+
+            return string.Format("{{ {{ GRAPH {0} {{ {1} }} {2} }} UNION {{ GRAPH {3} {{ {1} }} }} }}",
+                Graph(model.Baseline), triple, guard, Graph(model.Additions));
+        }
+
+        /// <summary>
+        /// The dataset clause for a layered read: <c>FROM NAMED</c> for each of the three graphs.
+        /// </summary>
+        /// <remarks>
+        /// <c>FROM NAMED</c> rather than <c>FROM</c>, because the overlay addresses the graphs
+        /// explicitly with <c>GRAPH</c> and must not have them merged into the default graph.
+        /// Naming all three also pins the dataset, so no unrelated graph in the store can leak
+        /// into a read.
+        /// </remarks>
+        internal static string NamedDatasetClause(ILayeredModel model)
+        {
+            if (model == null)
+            {
+                throw new ArgumentNullException(nameof(model));
+            }
+
+            return string.Format("FROM NAMED {0} FROM NAMED {1} FROM NAMED {2} ",
+                Graph(model.Baseline), Graph(model.Additions), Graph(model.Removals));
+        }
+
+        /// <summary>
+        /// Binds a variable to one or more known subjects with <c>VALUES</c>.
+        /// </summary>
+        /// <remarks>
+        /// This has to be emitted <b>before</b> the overlay it constrains. Restricting the
+        /// subject afterwards with <c>FILTER (?s = ...)</c> instead leaves the engine to push the
+        /// filter into a <c>UNION</c> containing an anti-join, which neither the in-memory engine
+        /// nor GraphDB does — measured at 15x and 38x respectively, against 1.0x for the
+        /// <c>VALUES</c> form. Binding up front turns every read into an indexed probe.
+        /// </remarks>
+        internal static string BindSubjects(string variable, IEnumerable<Uri> uris)
+        {
+            var result = new StringBuilder();
+
+            result.Append("VALUES ").Append(variable).Append(" { ");
+
+            foreach (Uri uri in uris)
+            {
+                result.Append(SparqlSerializer.SerializeUri(uri)).Append(' ');
+            }
+
+            result.Append("} ");
+
+            return result.ToString();
+        }
+
+        /// <summary>
+        /// Serializes a model's URI for use as a <c>GRAPH</c> or <c>FROM NAMED</c> operand.
+        /// </summary>
+        private static string Graph(IModel model)
+        {
+            return SparqlSerializer.SerializeUri(model.Uri);
+        }
+
+        /// <summary>
+        /// Indicates whether a serialized term is a SPARQL variable rather than an RDF term.
+        /// </summary>
+        private static bool IsVariable(string term)
+        {
+            return !string.IsNullOrEmpty(term) && (term[0] == '?' || term[0] == '$');
+        }
+    }
+}

--- a/Trinity/Query/OverlayQueryRewriter.cs
+++ b/Trinity/Query/OverlayQueryRewriter.cs
@@ -194,6 +194,25 @@ namespace Semiodesk.Trinity
                 differences.Add($"a projected expression changed: [{projectionsBefore}] became [{projectionsAfter}]");
             }
 
+            // GROUP BY and ORDER BY carry expressions too, and reach the output through the same
+            // reused serialization as HAVING and the projection - so they are exposed to the same
+            // negation defect and need the same check.
+            string groupByBefore = GroupBySignature(original.GroupBy);
+            string groupByAfter = GroupBySignature(check.GroupBy);
+
+            if (groupByBefore != groupByAfter)
+            {
+                differences.Add($"the GROUP BY expression {groupByBefore} became {groupByAfter}");
+            }
+
+            string orderByBefore = OrderBySignature(original.OrderBy);
+            string orderByAfter = OrderBySignature(check.OrderBy);
+
+            if (orderByBefore != orderByAfter)
+            {
+                differences.Add($"the ORDER BY expression {orderByBefore} became {orderByAfter}");
+            }
+
             if (differences.Count > 0)
             {
                 throw new NotSupportedException(
@@ -202,10 +221,43 @@ namespace Semiodesk.Trinity
                     string.Join("; ", differences) + "). Re-serializing a query relies on dotNetRDF, which is not " +
                     "faithful in every case - notably a negation wrapped around a comparison, where " +
                     "!(?x < 1) comes back as !?x < 1 and still parses. Trinity serializes FILTER and BIND " +
-                    "expressions itself to avoid that, but a projection or a HAVING clause is reused from " +
-                    "dotNetRDF's own output and cannot be repaired here, only detected. Rephrasing the " +
-                    "expression avoids it (here, ?x >= 1).\nOriginal: " + queryString + "\nRewritten: " + rewritten);
+                    "expressions itself to avoid that, but a projection, GROUP BY, HAVING or ORDER BY clause " +
+                    "is reused from dotNetRDF's own output and cannot be repaired here, only detected. " +
+                    "Rephrasing the expression avoids it (here, ?x >= 1).\nOriginal: " + queryString + "\nRewritten: " + rewritten);
             }
+        }
+
+        /// <summary>
+        /// Signature of a GROUP BY chain, following <c>Child</c> to the end.
+        /// </summary>
+        private static string GroupBySignature(VDS.RDF.Query.Grouping.ISparqlGroupBy groupBy)
+        {
+            var parts = new List<string>();
+
+            for (var current = groupBy; current != null; current = current.Child)
+            {
+                parts.Add(SparqlExpressionWriter.Signature(current.Expression) +
+                          (current.AssignVariable == null ? "" : " AS ?" + current.AssignVariable));
+            }
+
+            return parts.Count == 0 ? "(none)" : string.Join(" , ", parts);
+        }
+
+        /// <summary>
+        /// Signature of an ORDER BY chain, following <c>Child</c> to the end. Direction is included
+        /// because reversing it changes the answer just as surely as changing the expression.
+        /// </summary>
+        private static string OrderBySignature(VDS.RDF.Query.Ordering.ISparqlOrderBy orderBy)
+        {
+            var parts = new List<string>();
+
+            for (var current = orderBy; current != null; current = current.Child)
+            {
+                parts.Add((current.Descending ? "DESC" : "ASC") + "(" +
+                          SparqlExpressionWriter.Signature(current.Expression) + ")");
+            }
+
+            return parts.Count == 0 ? "(none)" : string.Join(" , ", parts);
         }
 
         /// <summary>
@@ -423,6 +475,15 @@ namespace Semiodesk.Trinity
                     throw Unsupported("an inline data block that could not be read");
                 }
 
+                // A union has to be recognised here, not only when it is reached as a child: an
+                // alternative of a union can itself be a union, and emitting that as a group would
+                // silently turn the inner disjunction into a join.
+                if (pattern.IsUnion)
+                {
+                    WriteUnion(pattern);
+                    return;
+                }
+
                 _body.Append("{ ");
 
                 WriteTriplePatterns(pattern);
@@ -439,29 +500,86 @@ namespace Semiodesk.Trinity
                 _body.Append('}');
             }
 
+            /// <summary>
+            /// Emits a union as <c>{ alt UNION alt ... }</c>.
+            /// </summary>
+            /// <remarks>
+            /// dotNetRDF models a union as a pattern whose own children are the alternatives, and an
+            /// alternative may itself be a union - <c>{A} UNION {B} UNION {C}</c> parses left-nested.
+            /// Each alternative therefore goes through <see cref="WritePattern"/>, which recognises a
+            /// nested union rather than flattening it into a join.
+            /// </remarks>
+            private void WriteUnion(DnrQuery.Patterns.GraphPattern pattern)
+            {
+                if (pattern.TriplePatterns.Count > 0 || pattern.IsFiltered || pattern.HasInlineData)
+                {
+                    throw Unsupported(
+                        "a UNION that also carries patterns of its own, which this rewriter does not model");
+                }
+
+                if (pattern.ChildGraphPatterns.Count == 0)
+                {
+                    throw Unsupported("a UNION with no alternatives");
+                }
+
+                _body.Append("{ ");
+
+                for (int i = 0; i < pattern.ChildGraphPatterns.Count; i++)
+                {
+                    if (i > 0)
+                    {
+                        _body.Append("UNION ");
+                    }
+
+                    WritePattern(pattern.ChildGraphPatterns[i]);
+                    _body.Append(' ');
+                }
+
+                _body.Append('}');
+            }
+
+            /// <summary>
+            /// Emits a group's triple patterns, preserving the order of anything order-sensitive.
+            /// </summary>
+            /// <remarks>
+            /// Match patterns are reordered so more-bound ones come first: order inside a basic graph
+            /// pattern is semantically irrelevant, but the overlay turns each pattern into a UNION
+            /// containing an anti-join, and an engine that cannot reorder joins across that evaluates
+            /// them as written - so a leading unbound pattern makes it materialize the whole effective
+            /// graph before applying any constraint.
+            /// <para>
+            /// That reordering is confined to contiguous <b>runs</b> of match patterns, because BIND is
+            /// not order-insensitive: its variable must not already be in scope where it appears, so
+            /// hoisting patterns across a BIND - or moving every BIND to the end - produces SPARQL that
+            /// is either invalid or means something else.
+            /// </para>
+            /// </remarks>
             private void WriteTriplePatterns(DnrQuery.Patterns.GraphPattern pattern)
             {
-                var matches = new List<IMatchTriplePattern>();
-                var others = new List<ITriplePattern>();
+                var run = new List<IMatchTriplePattern>();
 
                 foreach (ITriplePattern triplePattern in pattern.TriplePatterns)
                 {
                     if (triplePattern is IMatchTriplePattern match)
                     {
-                        matches.Add(match);
+                        run.Add(match);
+
+                        continue;
                     }
-                    else
-                    {
-                        others.Add(triplePattern);
-                    }
+
+                    FlushRun(run);
+                    WriteNonMatchPattern(triplePattern);
                 }
 
-                // More-bound patterns first. Order inside a basic graph pattern is semantically
-                // irrelevant, but the overlay turns each pattern into a UNION containing an
-                // anti-join, and an engine that cannot reorder joins across that evaluates them as
-                // written - so a leading unbound pattern makes it materialize the whole effective
-                // graph before applying any constraint.
-                foreach (IMatchTriplePattern match in matches.OrderByDescending(BoundTermCount))
+                FlushRun(run);
+            }
+
+            /// <summary>
+            /// Writes the accumulated run of match patterns, most-bound first, and clears it.
+            /// </summary>
+            private void FlushRun(List<IMatchTriplePattern> run)
+            {
+                foreach (IMatchTriplePattern match in run.OrderByDescending(BoundTermCount))
                 {
                     _body.Append(LayeredModelSparql.Overlay(
                         _model, Term(match.Subject), Term(match.Predicate), Term(match.Object)));
@@ -469,10 +587,7 @@ namespace Semiodesk.Trinity
                     _body.Append(' ');
                 }
 
-                foreach (ITriplePattern triplePattern in others)
-                {
-                    WriteNonMatchPattern(triplePattern);
-                }
+                run.Clear();
             }
 
             private void WriteNonMatchPattern(ITriplePattern triplePattern)
@@ -523,23 +638,6 @@ namespace Semiodesk.Trinity
             {
                 foreach (DnrQuery.Patterns.GraphPattern child in pattern.ChildGraphPatterns)
                 {
-                    if (child.IsUnion)
-                    {
-                        // A union is modelled as a child whose own children are the alternatives.
-                        for (int i = 0; i < child.ChildGraphPatterns.Count; i++)
-                        {
-                            if (i > 0)
-                            {
-                                _body.Append("UNION ");
-                            }
-
-                            WritePattern(child.ChildGraphPatterns[i]);
-                            _body.Append(' ');
-                        }
-
-                        continue;
-                    }
-
                     if (child.IsExists || child.IsNotExists)
                     {
                         throw Unsupported("an EXISTS / NOT EXISTS graph pattern");
@@ -655,9 +753,18 @@ namespace Semiodesk.Trinity
                 {
                     case VariablePattern _:
                     case NodeMatchPattern _:
+                        return item.ToString();
+
                     case BlankNodePattern _:
                     case FixedBlankNodePattern _:
-                        return item.ToString();
+                        // The overlay repeats each triple pattern across three basic graph patterns,
+                        // and SPARQL forbids a blank-node label appearing in more than one BGP of a
+                        // query - so the rewrite would not be legal SPARQL. This also covers the
+                        // property-list syntax [ ... ], which introduces a blank node.
+                        throw Unsupported(
+                            "a blank node in a triple pattern, including the [ ... ] property-list form. " +
+                            "The overlay repeats every pattern across three basic graph patterns, and SPARQL " +
+                            "does not allow a blank-node label to appear in more than one of them");
 
                     default:
                         throw Unsupported($"a term of type {item.GetType().Name}");

--- a/Trinity/Query/OverlayQueryRewriter.cs
+++ b/Trinity/Query/OverlayQueryRewriter.cs
@@ -1,0 +1,843 @@
+// LICENSE:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// AUTHORS:
+//
+//  Moritz Eberl <moritz@semiodesk.com>
+//  Sebastian Faubel <sebastian@semiodesk.com>
+//
+// Copyright (c) Semiodesk GmbH 2026
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using VDS.RDF.Query.Expressions;
+using VDS.RDF.Query.Expressions.Functions.Sparql.Boolean;
+using VDS.RDF.Query.Expressions.Primary;
+using VDS.RDF.Query.Patterns;
+using DnrParsing = VDS.RDF.Parsing;
+using DnrQuery = VDS.RDF.Query;
+
+namespace Semiodesk.Trinity
+{
+    /// <summary>
+    /// Rewrites a caller-supplied SPARQL query so that every triple pattern resolves against an
+    /// <see cref="ILayeredModel"/>'s effective graph instead of a single named graph.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Subtraction cannot live in a dataset clause, so a query run unchanged against a layered view
+    /// gives a wrong answer with no error — see <c>doc/adr/0041-layered-read-views.md</c>. This class
+    /// makes the honest version possible for the query forms it can prove it handles, and refuses
+    /// every other form with a reason.
+    /// </para>
+    /// <para>
+    /// It works on the query's <b>parse tree</b>, not its text. That matters: the abbreviations that
+    /// make text-level rewriting impractical — predicate-object lists (<c>;</c>), object lists
+    /// (<c>,</c>) and blank-node property lists (<c>[ ]</c>) — are already expanded into plain triple
+    /// patterns by the time the parser is done, so there is nothing left to disentangle.
+    /// </para>
+    /// <para>
+    /// <b>Whitelist, not blacklist.</b> Every pattern kind, and every filter expression, must be
+    /// recognised as safe; anything else throws. That is what keeps an unhandled form from silently
+    /// returning triples staged for removal.
+    /// </para>
+    /// </remarks>
+    internal static class OverlayQueryRewriter
+    {
+        /// <summary>
+        /// Rewrites <paramref name="queryString"/> against <paramref name="model"/>'s three graphs.
+        /// </summary>
+        /// <remarks>
+        /// The input must already have its Trinity <c>@parameters</c> substituted: the strict SPARQL
+        /// parser used here rejects them outright. Callers therefore pass
+        /// <c>ISparqlQuery.ToString()</c>, which performs the substitution.
+        /// </remarks>
+        /// <exception cref="NotSupportedException">
+        /// Thrown, with the specific reason, if the query cannot be rewritten faithfully.
+        /// </exception>
+        internal static string Rewrite(ILayeredModel model, string queryString)
+        {
+            if (model == null)
+            {
+                throw new ArgumentNullException(nameof(model));
+            }
+
+            DnrQuery.SparqlQuery parsed = Parse(queryString);
+
+            string rewritten = new Walker(model).RewriteQuery(parsed, outermost: true);
+
+            // Re-parse the result and compare the parts this class did not intend to change. A
+            // serialization slip would otherwise be indistinguishable from a correct rewrite, and
+            // the whole point of the overlay is that wrong answers are never silent.
+            VerifyRoundTrip(parsed, rewritten, queryString);
+
+            return rewritten;
+        }
+
+        private static DnrQuery.SparqlQuery Parse(string queryString)
+        {
+            try
+            {
+                return new DnrParsing.SparqlQueryParser().ParseFromString(queryString);
+            }
+            catch (Exception ex)
+            {
+                throw new NotSupportedException(
+                    "The query could not be parsed, so it cannot be rewritten to honour the layered " +
+                    "baseline/additions/removals overlay. Note that Trinity's own tokenizer accepts a " +
+                    "wider, extended syntax than the strict SPARQL parser used here, so a query may be " +
+                    "accepted by a plain model and refused by a layered one. Parser error: " + ex.Message, ex);
+            }
+        }
+
+        /// <summary>
+        /// Confirms the rewrite preserved everything outside the WHERE clause.
+        /// </summary>
+        private static void VerifyRoundTrip(DnrQuery.SparqlQuery original, string rewritten, string queryString)
+        {
+            DnrQuery.SparqlQuery check;
+
+            try
+            {
+                check = new DnrParsing.SparqlQueryParser().ParseFromString(rewritten);
+            }
+            catch (Exception ex)
+            {
+                throw new NotSupportedException(
+                    "Rewriting the query for the layered overlay produced SPARQL that does not parse. This is a " +
+                    "defect in the rewriter rather than a problem with the query; it is reported instead of " +
+                    "executed because an unparseable rewrite is preferable to a silently wrong answer.\n" +
+                    "Original: " + queryString + "\nRewritten: " + rewritten, ex);
+            }
+
+            var differences = new List<string>();
+
+            if (check.QueryType != original.QueryType)
+            {
+                differences.Add($"query form {original.QueryType} became {check.QueryType}");
+            }
+
+            if (check.Limit != original.Limit)
+            {
+                differences.Add($"LIMIT {original.Limit} became {check.Limit}");
+            }
+
+            if (check.Offset != original.Offset)
+            {
+                differences.Add($"OFFSET {original.Offset} became {check.Offset}");
+            }
+
+            string before = string.Join(",", original.Variables.Where(v => v.IsResultVariable).Select(v => v.Name));
+            string after = string.Join(",", check.Variables.Where(v => v.IsResultVariable).Select(v => v.Name));
+
+            if (before != after)
+            {
+                differences.Add($"projected variables [{before}] became [{after}]");
+            }
+
+            // Filters are re-emitted through dotNetRDF's own serialization, which is not always
+            // faithful: FILTER(!(?r < 3)) comes back as FILTER(!?r < 3), i.e. (!?r) < 3, and it
+            // reparses cleanly. Comparing the expression trees structurally is what turns that
+            // upstream defect into a refusal instead of a quietly different answer.
+            List<string> filtersBefore = FilterSignatures(original.RootGraphPattern);
+
+            // The overlay adds its own FILTER NOT EXISTS guard for every fully ground pattern, so
+            // those have to come out of the comparison. It is safe to drop all of them because a
+            // caller's own EXISTS / NOT EXISTS is refused outright - anything matching here is ours.
+            List<string> filtersAfter = FilterSignatures(check.RootGraphPattern)
+                .Where(signature => !signature.StartsWith("NOT EXISTS(", StringComparison.Ordinal))
+                .ToList();
+
+            if (!filtersBefore.SequenceEqual(filtersAfter))
+            {
+                differences.Add(
+                    "a FILTER expression did not survive re-serialization: [" +
+                    string.Join(" | ", filtersBefore) + "] became [" + string.Join(" | ", filtersAfter) + "]");
+            }
+
+            // HAVING and the projection expressions are not re-emitted by this class - they come from
+            // dotNetRDF's serialization of the head and the solution modifiers, which is reused
+            // verbatim. So they cannot be repaired here, only checked: a negation inside one is
+            // mangled exactly as it is inside a filter, and would otherwise pass unnoticed.
+            string havingBefore = SparqlExpressionWriter.Signature(original.Having?.Expression);
+            string havingAfter = SparqlExpressionWriter.Signature(check.Having?.Expression);
+
+            if (havingBefore != havingAfter)
+            {
+                differences.Add($"the HAVING expression {havingBefore} became {havingAfter}");
+            }
+
+            string projectionsBefore = ProjectionSignatures(original);
+            string projectionsAfter = ProjectionSignatures(check);
+
+            if (projectionsBefore != projectionsAfter)
+            {
+                differences.Add($"a projected expression changed: [{projectionsBefore}] became [{projectionsAfter}]");
+            }
+
+            if (differences.Count > 0)
+            {
+                throw new NotSupportedException(
+                    "This query cannot be run against a layered model: rewriting it to honour the " +
+                    "baseline/additions/removals overlay changed part of it that had to be preserved (" +
+                    string.Join("; ", differences) + "). Re-serializing a query relies on dotNetRDF, which is not " +
+                    "faithful in every case - notably a negation wrapped around a comparison, where " +
+                    "!(?x < 1) comes back as !?x < 1 and still parses. Trinity serializes FILTER and BIND " +
+                    "expressions itself to avoid that, but a projection or a HAVING clause is reused from " +
+                    "dotNetRDF's own output and cannot be repaired here, only detected. Rephrasing the " +
+                    "expression avoids it (here, ?x >= 1).\nOriginal: " + queryString + "\nRewritten: " + rewritten);
+            }
+        }
+
+        /// <summary>
+        /// Every filter attached to a group, from both places dotNetRDF can hold one.
+        /// </summary>
+        private static IEnumerable<VDS.RDF.Query.Filters.ISparqlFilter> Filters(DnrQuery.Patterns.GraphPattern pattern)
+        {
+            if (pattern.IsFiltered && pattern.Filter != null)
+            {
+                yield return pattern.Filter;
+            }
+
+            foreach (VDS.RDF.Query.Filters.ISparqlFilter filter in pattern.UnplacedFilters)
+            {
+                yield return filter;
+            }
+        }
+
+        /// <summary>
+        /// Signatures of the projected expressions and aggregates, in projection order.
+        /// </summary>
+        private static string ProjectionSignatures(DnrQuery.SparqlQuery query)
+        {
+            var parts = new List<string>();
+
+            foreach (DnrQuery.SparqlVariable variable in query.Variables.Where(v => v.IsResultVariable))
+            {
+                if (variable.IsAggregate && variable.Aggregate != null)
+                {
+                    parts.Add(variable.Name + "=" + variable.Aggregate.Functor + "(" +
+                              SparqlExpressionWriter.Signature(variable.Aggregate.Expression) + ")");
+                }
+                else if (variable.IsProjection && variable.Projection != null)
+                {
+                    parts.Add(variable.Name + "=" + SparqlExpressionWriter.Signature(variable.Projection));
+                }
+                else
+                {
+                    parts.Add(variable.Name);
+                }
+            }
+
+            return string.Join(" | ", parts);
+        }
+
+        /// <summary>
+        /// Collects a structural signature of every FILTER expression in a pattern tree, so a
+        /// re-serialization that changed one can be detected.
+        /// </summary>
+        /// <remarks>
+        /// Sorted rather than compared in tree order: the rewrite moves filters to the end of their
+        /// group, which is semantically irrelevant but would otherwise look like a difference.
+        /// </remarks>
+        private static List<string> FilterSignatures(DnrQuery.Patterns.GraphPattern pattern)
+        {
+            var signatures = new HashSet<string>(StringComparer.Ordinal);
+
+            Collect(pattern, signatures);
+
+            // Distinct rather than a multiset: dotNetRDF can expose one filter through both
+            // GraphPattern.Filter and GraphPattern.UnplacedFilters, and a repeated filter is
+            // idempotent anyway, so a count difference carries no meaning.
+            var sorted = signatures.ToList();
+            sorted.Sort(StringComparer.Ordinal);
+
+            return sorted;
+        }
+
+        private static void Collect(DnrQuery.Patterns.GraphPattern pattern, HashSet<string> signatures)
+        {
+            if (pattern == null)
+            {
+                return;
+            }
+
+
+            foreach (ITriplePattern triplePattern in pattern.TriplePatterns)
+            {
+                switch (triplePattern)
+                {
+                    case IFilterPattern filter:
+                        signatures.Add(SparqlExpressionWriter.Signature(filter.Filter.Expression));
+                        break;
+                    case IAssignmentPattern assignment:
+                        signatures.Add(SparqlExpressionWriter.Signature(assignment.AssignExpression));
+                        break;
+                    case ISubQueryPattern subQuery:
+                        Collect(subQuery.SubQuery.RootGraphPattern, signatures);
+                        break;
+                }
+            }
+
+            foreach (IAssignmentPattern assignment in pattern.UnplacedAssignments)
+            {
+                signatures.Add(SparqlExpressionWriter.Signature(assignment.AssignExpression));
+            }
+
+            foreach (VDS.RDF.Query.Filters.ISparqlFilter filter in Filters(pattern))
+            {
+                signatures.Add(SparqlExpressionWriter.Signature(filter.Expression));
+            }
+
+            foreach (DnrQuery.Patterns.GraphPattern child in pattern.ChildGraphPatterns)
+            {
+                Collect(child, signatures);
+            }
+        }
+
+        /// <summary>
+        /// Walks one query's pattern tree and emits the rewritten SPARQL.
+        /// </summary>
+        private sealed class Walker
+        {
+            private readonly ILayeredModel _model;
+
+            private readonly StringBuilder _body = new StringBuilder();
+
+            internal Walker(ILayeredModel model)
+            {
+                _model = model;
+            }
+
+            /// <summary>
+            /// Rewrites a whole query. Only the outermost query may carry a dataset clause; a
+            /// sub-<c>SELECT</c> must not.
+            /// </summary>
+            internal string RewriteQuery(DnrQuery.SparqlQuery query, bool outermost)
+            {
+                RequireSupportedForm(query);
+
+                if (query.DefaultGraphNames.Any() || query.NamedGraphNames.Any())
+                {
+                    throw Unsupported(
+                        "the query declares its own dataset clause (FROM / FROM NAMED). A layered view defines the " +
+                        "dataset itself, so a query cannot also choose one");
+                }
+
+                // Serialize the pattern tree first; the head and solution modifiers are then taken
+                // from dotNetRDF's own serialization of the same query, which is authoritative for
+                // its own AST and saves re-implementing projection, GROUP BY, HAVING and ORDER BY.
+                var walker = new Walker(_model);
+                walker.WritePattern(query.RootGraphPattern);
+                string body = walker._body.ToString();
+
+                string normalized = query.ToString();
+                SplitAroundRootPattern(normalized, out string head, out string tail);
+
+                string dataset = outermost ? LayeredModelSparql.NamedDatasetClause(_model) : string.Empty;
+
+                var result = new StringBuilder();
+
+                result.Append(head);
+
+                if (head.Length > 0 && !head.EndsWith(" ", StringComparison.Ordinal))
+                {
+                    result.Append(' ');
+                }
+
+                result.Append(dataset).Append("WHERE ").Append(body);
+
+                if (tail.Length > 0)
+                {
+                    result.Append(' ').Append(tail);
+                }
+
+                return result.ToString().Trim();
+            }
+
+            private static void RequireSupportedForm(DnrQuery.SparqlQuery query)
+            {
+                switch (query.QueryType)
+                {
+                    case DnrQuery.SparqlQueryType.Ask:
+                    case DnrQuery.SparqlQueryType.Select:
+                    case DnrQuery.SparqlQueryType.SelectAll:
+                    case DnrQuery.SparqlQueryType.SelectAllDistinct:
+                    case DnrQuery.SparqlQueryType.SelectAllReduced:
+                    case DnrQuery.SparqlQueryType.SelectDistinct:
+                    case DnrQuery.SparqlQueryType.SelectReduced:
+                        return;
+
+                    case DnrQuery.SparqlQueryType.Construct:
+                        throw Unsupported(
+                            "CONSTRUCT: its template describes triples to build rather than to match, so the overlay " +
+                            "must not be applied there, and distinguishing the two reliably is not supported");
+
+                    case DnrQuery.SparqlQueryType.Describe:
+                    case DnrQuery.SparqlQueryType.DescribeAll:
+                        throw Unsupported(
+                            "DESCRIBE: the store decides which triples to return, so there is no graph pattern to " +
+                            "rewrite. Read whole resources with GetResource instead, which does honour the overlay");
+
+                    default:
+                        throw Unsupported($"query form {query.QueryType}");
+                }
+            }
+
+            private void WritePattern(DnrQuery.Patterns.GraphPattern pattern)
+            {
+                if (pattern.IsGraph)
+                {
+                    throw Unsupported(
+                        $"an explicit GRAPH block (GRAPH {pattern.GraphSpecifier?.Value}). A layered view is itself a " +
+                        "graph-level construct built from three graphs, so naming one of them would read past the " +
+                        "overlay - and GRAPH ?g would expose the removals graph as ordinary data");
+                }
+
+                if (pattern.IsService)
+                {
+                    throw Unsupported("a SERVICE clause: the remote endpoint knows nothing of the overlay");
+                }
+
+                if (pattern.HasInlineData && pattern.InlineData == null)
+                {
+                    throw Unsupported("an inline data block that could not be read");
+                }
+
+                _body.Append("{ ");
+
+                WriteTriplePatterns(pattern);
+                WriteChildPatterns(pattern);
+                WriteAssignments(pattern);
+                WriteFilters(pattern);
+
+                if (pattern.HasInlineData)
+                {
+                    // VALUES binds solutions directly and never touches a graph.
+                    _body.Append(pattern.InlineData.ToString()).Append(' ');
+                }
+
+                _body.Append('}');
+            }
+
+            private void WriteTriplePatterns(DnrQuery.Patterns.GraphPattern pattern)
+            {
+                var matches = new List<IMatchTriplePattern>();
+                var others = new List<ITriplePattern>();
+
+                foreach (ITriplePattern triplePattern in pattern.TriplePatterns)
+                {
+                    if (triplePattern is IMatchTriplePattern match)
+                    {
+                        matches.Add(match);
+                    }
+                    else
+                    {
+                        others.Add(triplePattern);
+                    }
+                }
+
+                // More-bound patterns first. Order inside a basic graph pattern is semantically
+                // irrelevant, but the overlay turns each pattern into a UNION containing an
+                // anti-join, and an engine that cannot reorder joins across that evaluates them as
+                // written - so a leading unbound pattern makes it materialize the whole effective
+                // graph before applying any constraint.
+                foreach (IMatchTriplePattern match in matches.OrderByDescending(BoundTermCount))
+                {
+                    _body.Append(LayeredModelSparql.Overlay(
+                        _model, Term(match.Subject), Term(match.Predicate), Term(match.Object)));
+
+                    _body.Append(' ');
+                }
+
+                foreach (ITriplePattern triplePattern in others)
+                {
+                    WriteNonMatchPattern(triplePattern);
+                }
+            }
+
+            private void WriteNonMatchPattern(ITriplePattern triplePattern)
+            {
+                switch (triplePattern)
+                {
+                    case ISubQueryPattern subQuery:
+                        _body.Append("{ ")
+                             .Append(new Walker(_model).RewriteQuery(subQuery.SubQuery, outermost: false))
+                             .Append(" } ");
+                        break;
+
+                    case IAssignmentPattern assignment:
+                        // BIND / LET: computes a value, never reads a graph. Written through our own
+                        // serializer because dotNetRDF mangles a negation here too.
+                        RequireNoGraphAccess(assignment.AssignExpression);
+                        _body.Append("BIND(")
+                             .Append(SparqlExpressionWriter.Write(assignment.AssignExpression))
+                             .Append(" AS ?").Append(assignment.VariableName).Append(") ");
+                        break;
+
+                    case BindingsPattern inlineData:
+                        _body.Append(inlineData.ToString()).Append(' ');
+                        break;
+
+                    case IFilterPattern filter:
+                        RequireNoGraphAccess(filter.Filter.Expression);
+                        _body.Append("FILTER(")
+                             .Append(SparqlExpressionWriter.Write(filter.Filter.Expression))
+                             .Append(") ");
+                        break;
+
+                    case IPropertyPathPattern _:
+                        throw Unsupported(
+                            "a property path. A path walks intermediate nodes that must themselves resolve against " +
+                            "the effective graph, and a transitive path (+ or *) has no fixed expansion to rewrite " +
+                            "into, so it cannot be handled pattern by pattern");
+
+                    case IPropertyFunctionPattern _:
+                        throw Unsupported("a property function");
+
+                    default:
+                        throw Unsupported($"a pattern of type {triplePattern.GetType().Name}");
+                }
+            }
+
+            private void WriteChildPatterns(DnrQuery.Patterns.GraphPattern pattern)
+            {
+                foreach (DnrQuery.Patterns.GraphPattern child in pattern.ChildGraphPatterns)
+                {
+                    if (child.IsUnion)
+                    {
+                        // A union is modelled as a child whose own children are the alternatives.
+                        for (int i = 0; i < child.ChildGraphPatterns.Count; i++)
+                        {
+                            if (i > 0)
+                            {
+                                _body.Append("UNION ");
+                            }
+
+                            WritePattern(child.ChildGraphPatterns[i]);
+                            _body.Append(' ');
+                        }
+
+                        continue;
+                    }
+
+                    if (child.IsExists || child.IsNotExists)
+                    {
+                        throw Unsupported("an EXISTS / NOT EXISTS graph pattern");
+                    }
+
+                    if (child.IsOptional)
+                    {
+                        _body.Append("OPTIONAL ");
+                    }
+                    else if (child.IsMinus)
+                    {
+                        _body.Append("MINUS ");
+                    }
+
+                    WritePattern(child);
+                    _body.Append(' ');
+                }
+            }
+
+            /// <summary>
+            /// Emits the BIND clauses dotNetRDF parked as "unplaced".
+            /// </summary>
+            /// <remarks>
+            /// A parser may hold an assignment in <c>UnplacedAssignments</c> rather than among the
+            /// group's triple patterns, to be positioned later during optimisation. Iterating only
+            /// <c>TriplePatterns</c> would drop it from the rewritten query - losing a binding
+            /// silently, which is worse than refusing.
+            /// </remarks>
+            private void WriteAssignments(DnrQuery.Patterns.GraphPattern pattern)
+            {
+                foreach (IAssignmentPattern assignment in pattern.UnplacedAssignments)
+                {
+                    RequireNoGraphAccess(assignment.AssignExpression);
+
+                    _body.Append("BIND(")
+                         .Append(SparqlExpressionWriter.Write(assignment.AssignExpression))
+                         .Append(" AS ?").Append(assignment.VariableName).Append(") ");
+                }
+            }
+
+            /// <summary>
+            /// Emits every filter that applies to a group, each exactly once.
+            /// </summary>
+            /// <remarks>
+            /// A filter can be reachable through both <c>Filter</c> and <c>UnplacedFilters</c>, so the
+            /// two are merged and de-duplicated by structure. Emitting one twice would be harmless -
+            /// a filter is idempotent - but omitting one would not, and de-duplicating here keeps the
+            /// round-trip comparison honest.
+            /// </remarks>
+            private void WriteFilters(DnrQuery.Patterns.GraphPattern pattern)
+            {
+                var written = new HashSet<string>();
+
+                foreach (VDS.RDF.Query.Filters.ISparqlFilter filter in Filters(pattern))
+                {
+                    RequireNoGraphAccess(filter.Expression);
+
+                    string text = SparqlExpressionWriter.Write(filter.Expression);
+
+                    if (written.Add(SparqlExpressionWriter.Signature(filter.Expression)))
+                    {
+                        _body.Append("FILTER(").Append(text).Append(") ");
+                    }
+                }
+            }
+
+            /// <summary>
+            /// Refuses a filter expression that reads a graph of its own.
+            /// </summary>
+            /// <remarks>
+            /// <c>FILTER EXISTS { ... }</c> and <c>FILTER NOT EXISTS { ... }</c> do not appear as child
+            /// graph patterns; they are an <c>ExistsFunction</c> wrapping a <c>GraphPatternTerm</c>
+            /// inside the filter expression. Filters are re-emitted verbatim, so without this check
+            /// that nested pattern would bypass the overlay entirely and match against the raw
+            /// baseline — the removals graph would be ignored and nothing would say so.
+            /// </remarks>
+            private static void RequireNoGraphAccess(ISparqlExpression expression)
+            {
+                if (expression == null)
+                {
+                    return;
+                }
+
+                if (expression is ExistsFunction || expression is GraphPatternTerm ||
+                    expression.Type == SparqlExpressionType.GraphOperator)
+                {
+                    throw Unsupported(
+                        "a filter that matches a graph pattern of its own (EXISTS / NOT EXISTS). Filters are " +
+                        "re-emitted unchanged, so its nested pattern would read the baseline directly and ignore " +
+                        "the triples staged for removal");
+                }
+
+                foreach (ISparqlExpression argument in expression.Arguments)
+                {
+                    RequireNoGraphAccess(argument);
+                }
+            }
+
+            private static int BoundTermCount(IMatchTriplePattern match)
+            {
+                int bound = 0;
+
+                if (!(match.Subject is VariablePattern)) bound++;
+                if (!(match.Predicate is VariablePattern)) bound++;
+                if (!(match.Object is VariablePattern)) bound++;
+
+                return bound;
+            }
+
+            private static string Term(PatternItem item)
+            {
+                switch (item)
+                {
+                    case VariablePattern _:
+                    case NodeMatchPattern _:
+                    case BlankNodePattern _:
+                    case FixedBlankNodePattern _:
+                        return item.ToString();
+
+                    default:
+                        throw Unsupported($"a term of type {item.GetType().Name}");
+                }
+            }
+
+            private static NotSupportedException Unsupported(string what)
+            {
+                return new NotSupportedException(
+                    "This query cannot be run against a layered model because it contains " + what + ". " +
+                    "The baseline/additions/removals overlay has to be applied inside every graph pattern, and this " +
+                    "form cannot be rewritten faithfully - so it is refused rather than answered with triples that " +
+                    "are staged for removal. Query the Baseline, Additions or Removals models directly, or use " +
+                    "GetResource / GetResources / ContainsResource / AsQueryable<T>(). " +
+                    "See doc/adr/0041-layered-read-views.md.");
+            }
+
+            /// <summary>
+            /// Splits dotNetRDF's serialization of a query around its root group graph pattern, so the
+            /// projection and the solution modifiers can be reused verbatim.
+            /// </summary>
+            /// <remarks>
+            /// Brace matching is literal-aware: a query may legitimately contain <c>"}"</c> inside a
+            /// string, in the projection as well as in the pattern.
+            /// </remarks>
+            private static void SplitAroundRootPattern(string query, out string head, out string tail)
+            {
+                int open = IndexOfRootBrace(query);
+
+                if (open < 0)
+                {
+                    throw Unsupported("no group graph pattern that could be rewritten");
+                }
+
+                int close = IndexOfMatchingBrace(query, open);
+
+                if (close < 0)
+                {
+                    throw Unsupported("an unbalanced group graph pattern");
+                }
+
+                head = query.Substring(0, open).TrimEnd();
+
+                // Drop the WHERE keyword; it is re-emitted with the rewritten body.
+                if (head.EndsWith("WHERE", StringComparison.OrdinalIgnoreCase))
+                {
+                    head = head.Substring(0, head.Length - "WHERE".Length).TrimEnd();
+                }
+
+                tail = query.Substring(close + 1).Trim();
+            }
+
+            private static int IndexOfRootBrace(string query)
+            {
+                for (int i = 0; i < query.Length; i++)
+                {
+                    i = SkipLiteralOrIri(query, i);
+
+                    if (i < query.Length && query[i] == '{')
+                    {
+                        return i;
+                    }
+                }
+
+                return -1;
+            }
+
+            private static int IndexOfMatchingBrace(string query, int open)
+            {
+                int depth = 0;
+
+                for (int i = open; i < query.Length; i++)
+                {
+                    i = SkipLiteralOrIri(query, i);
+
+                    if (i >= query.Length)
+                    {
+                        break;
+                    }
+
+                    if (query[i] == '{')
+                    {
+                        depth++;
+                    }
+                    else if (query[i] == '}')
+                    {
+                        depth--;
+
+                        if (depth == 0)
+                        {
+                            return i;
+                        }
+                    }
+                }
+
+                return -1;
+            }
+
+            /// <summary>
+            /// Indicates whether an IRI reference starts at <paramref name="start"/>, and if so where
+            /// its closing angle bracket is.
+            /// </summary>
+            private static bool IsIriRef(string query, int start, out int end)
+            {
+                end = start;
+
+                for (int i = start + 1; i < query.Length; i++)
+                {
+                    char c = query[i];
+
+                    if (c == '>')
+                    {
+                        end = i;
+                        return true;
+                    }
+
+                    if (char.IsWhiteSpace(c) || c == '<' || c == '"' || c == '{' ||
+                        c == '}' || c == '|' || c == '^' || c == '`')
+                    {
+                        return false;
+                    }
+                }
+
+                return false;
+            }
+
+            /// <summary>
+            /// If a literal or IRI starts at <paramref name="i"/>, returns the index of its last
+            /// character; otherwise returns <paramref name="i"/> unchanged.
+            /// </summary>
+            private static int SkipLiteralOrIri(string query, int i)
+            {
+                if (i >= query.Length)
+                {
+                    return i;
+                }
+
+                char c = query[i];
+
+                if (c == '<')
+                {
+                    // '<' is also the less-than operator, so only skip when this really is an IRI.
+                    // Per the SPARQL grammar an IRIREF runs to the next '>' and may not contain
+                    // whitespace or any of <>"{}|^`. Treating `?r < 3` as an IRI would swallow the
+                    // rest of the query, closing braces included.
+                    return IsIriRef(query, i, out int end) ? end : i;
+                }
+
+                if (c != '"' && c != '\'')
+                {
+                    return i;
+                }
+
+                string longQuote = new string(c, 3);
+                bool isLong = i + 2 < query.Length && query.Substring(i, 3) == longQuote;
+                int start = isLong ? i + 3 : i + 1;
+
+                for (int j = start; j < query.Length; j++)
+                {
+                    if (query[j] == '\\')
+                    {
+                        j++;
+                        continue;
+                    }
+
+                    if (isLong)
+                    {
+                        if (j + 2 < query.Length && query.Substring(j, 3) == longQuote)
+                        {
+                            return j + 2;
+                        }
+                    }
+                    else if (query[j] == c)
+                    {
+                        return j;
+                    }
+                }
+
+                return query.Length;
+            }
+        }
+    }
+}

--- a/Trinity/Query/OverlayQueryRewriter.cs
+++ b/Trinity/Query/OverlayQueryRewriter.cs
@@ -620,11 +620,8 @@ namespace Semiodesk.Trinity
                              .Append(") ");
                         break;
 
-                    case IPropertyPathPattern _:
-                        throw Unsupported(
-                            "a property path. A path walks intermediate nodes that must themselves resolve against " +
-                            "the effective graph, and a transitive path (+ or *) has no fixed expansion to rewrite " +
-                            "into, so it cannot be handled pattern by pattern");
+                    case IPropertyPathPattern path:
+                        throw UnsupportedPath(path);
 
                     case IPropertyFunctionPattern _:
                         throw Unsupported("a property function");
@@ -768,6 +765,59 @@ namespace Semiodesk.Trinity
 
                     default:
                         throw Unsupported($"a term of type {item.GetType().Name}");
+                }
+            }
+
+            /// <summary>
+            /// Refuses a property path, distinguishing the forms that are impossible from the forms
+            /// that are merely not implemented yet.
+            /// </summary>
+            /// <remarks>
+            /// <para>
+            /// The <b>unbounded</b> forms - <c>p+</c>, <c>p*</c>, <c>p{n,}</c> - cannot be supported at
+            /// all, and the reason is sharper than "paths are hard": <b>transitive closure does not
+            /// distribute over the union of the layers</b>. With <c>a p b</c> in the baseline and
+            /// <c>b p c</c> in the additions, the effective graph contains the chain, so
+            /// <c>a p+ c</c> must hold - but evaluating the closure inside each graph and unioning the
+            /// results yields only <c>b</c>, because neither graph contains the whole chain. So the
+            /// path cannot be pushed inside the overlay's GRAPH blocks, and there is no finite
+            /// expansion into triple patterns to push the overlay into instead. The only way to
+            /// evaluate one correctly would be to materialize the effective graph first, which is a
+            /// write, and O(baseline) per query.
+            /// </para>
+            /// <para>
+            /// The <b>bounded</b> forms are a different matter and are simply not implemented:
+            /// <c>^p</c> is a subject/object swap, <c>p1/p2</c> expands into two patterns joined by a
+            /// fresh variable, <c>p1|p2</c> into a UNION, and <c>!p</c> into a variable predicate with
+            /// a filter - each of which the overlay then handles one pattern at a time. They are
+            /// refused only because the expansion has not been written, not because it cannot be.
+            /// </para>
+            /// </remarks>
+            private static NotSupportedException UnsupportedPath(IPropertyPathPattern path)
+            {
+                string kind = path.Path == null ? "a property path" : PathKind(path.Path);
+
+                return Unsupported(kind);
+            }
+
+            private static string PathKind(VDS.RDF.Query.Paths.ISparqlPath path)
+            {
+                switch (path)
+                {
+                    case VDS.RDF.Query.Paths.OneOrMore _:
+                    case VDS.RDF.Query.Paths.ZeroOrMore _:
+                    case VDS.RDF.Query.Paths.NOrMore _:
+                        return "an unbounded property path (+, * or {n,}). This one cannot be supported: " +
+                               "transitive closure does not distribute over the union of the three layers - a chain " +
+                               "whose hops come from different layers exists in the effective graph but in none of " +
+                               "them alone - and there is no finite expansion into triple patterns to apply the " +
+                               "overlay to instead";
+
+                    default:
+                        return "a property path. The unbounded forms (+, *) cannot be supported at all, because " +
+                               "transitive closure does not distribute over the union of the layers; the bounded " +
+                               "forms (^, /, |, !) could be expanded into ordinary triple patterns but that is not " +
+                               "implemented yet";
                 }
             }
 

--- a/Trinity/Query/Sparql/SparqlQueryProvider.cs
+++ b/Trinity/Query/Sparql/SparqlQueryProvider.cs
@@ -48,10 +48,38 @@ namespace Semiodesk.Trinity.Query.Sparql
 
         private readonly bool _inferenceEnabled;
 
+        /// <summary>
+        /// Non-null when querying a layered model, in which case every emitted triple pattern is
+        /// wrapped in its overlay.
+        /// </summary>
+        private readonly ILayeredModel _layered;
+
         public SparqlQueryProvider(IModel model, bool inferenceEnabled)
         {
             _model = model ?? throw new ArgumentNullException(nameof(model));
             _inferenceEnabled = inferenceEnabled;
+            _layered = model as ILayeredModel;
+
+            if (_layered != null)
+            {
+                LayeredModel.RequireNoInferencing(inferenceEnabled);
+            }
+        }
+
+        /// <summary>
+        /// Serializes a translated query, applying the layered overlay when there is one, and marks
+        /// it so a layered model will accept it.
+        /// </summary>
+        private ISparqlQuery CreateQuery(SparqlQueryModel translated)
+        {
+            var query = new SparqlQuery(SparqlQueryWriter.Write(translated, _layered)) { Model = _model };
+
+            if (_layered != null)
+            {
+                query.IsOverlayApplied = true;
+            }
+
+            return query;
         }
 
         public IQueryable<TElement> CreateQuery<TElement>(Expression expression)
@@ -71,7 +99,7 @@ namespace Semiodesk.Trinity.Query.Sparql
         {
             QueryTranslation translation = new SparqlQueryTranslator().Translate(expression);
 
-            var query = new SparqlQuery(SparqlQueryWriter.Write(translation.Query)) { Model = _model };
+            ISparqlQuery query = CreateQuery(translation.Query);
 
             switch (translation.Kind)
             {
@@ -225,7 +253,7 @@ namespace Semiodesk.Trinity.Query.Sparql
                 byUri[((IResource)resource).Uri.OriginalString] = resource;
             }
 
-            var query = new SparqlQuery(SparqlQueryWriter.Write(translation.MultiplicityQuery)) { Model = _model };
+            ISparqlQuery query = CreateQuery(translation.MultiplicityQuery);
             var list = (IList)Activator.CreateInstance(typeof(List<>).MakeGenericType(translation.ElementType));
 
             foreach (BindingSet bindings in _model.ExecuteQuery(query, _inferenceEnabled).GetBindings())

--- a/Trinity/Query/Sparql/SparqlQueryTranslator.cs
+++ b/Trinity/Query/Sparql/SparqlQueryTranslator.cs
@@ -2392,8 +2392,14 @@ namespace Semiodesk.Trinity.Query.Sparql
             outer.Projections.Add(new Projection(subject));
             outer.Projections.Add(new Projection(new VariableTerm("p")));
             outer.Projections.Add(new Projection(new VariableTerm("o")));
-            outer.Where.Add(new TriplePattern(subject, new VariableTerm("p"), new VariableTerm("o")));
 
+            // The selection is emitted BEFORE the wildcard ?s ?p ?o that fetches each matched
+            // resource's triples. Pattern order inside a basic graph pattern is semantically
+            // irrelevant, but it is not irrelevant to the plan: over a layered model every pattern
+            // becomes a UNION containing an anti-join, and an engine that cannot reorder joins
+            // across that evaluates them as written - so a leading wildcard makes it materialize
+            // the whole effective graph before applying any constraint. Measured at four orders of
+            // magnitude on the in-memory engine. Harmless for a plain model, which reorders freely.
             if (_limit.HasValue || _offset.HasValue || _distinct || subject != Subject)
             {
                 var inner = new SelectQuery { IsDistinct = true, Limit = _limit, Offset = _offset, Where = selection };
@@ -2416,6 +2422,8 @@ namespace Semiodesk.Trinity.Query.Sparql
 
                 outer.OrderBy.AddRange(_orderings);
             }
+
+            outer.Where.Add(new TriplePattern(subject, new VariableTerm("p"), new VariableTerm("o")));
 
             return outer;
         }

--- a/Trinity/Query/Sparql/SparqlQueryWriter.cs
+++ b/Trinity/Query/Sparql/SparqlQueryWriter.cs
@@ -40,9 +40,37 @@ namespace Semiodesk.Trinity.Query.Sparql
     {
         private readonly StringBuilder _builder = new StringBuilder();
 
+        /// <summary>
+        /// When set, every triple pattern is emitted wrapped in this model's
+        /// <c>(baseline - removals) union additions</c> overlay instead of as a bare pattern.
+        /// </summary>
+        private readonly ILayeredModel _layered;
+
+        private SparqlQueryWriter(ILayeredModel layered = null)
+        {
+            _layered = layered;
+        }
+
         public static string Write(SparqlQueryModel query)
         {
-            var writer = new SparqlQueryWriter();
+            return Write(query, null);
+        }
+
+        /// <summary>
+        /// Serializes the query, resolving every triple pattern against <paramref name="layered"/>'s
+        /// effective graph when one is given.
+        /// </summary>
+        /// <remarks>
+        /// Wrapping happens in exactly one place - the <see cref="TriplePattern"/> arm of
+        /// <see cref="WritePattern"/> - because that is the only node kind that resolves against the
+        /// data. Groups, OPTIONAL, UNION, MINUS and sub-selects merely contain patterns, and BIND and
+        /// VALUES touch no graph at all, so they need no change and the rewrite is complete over the
+        /// AST by construction. The <c>default:</c> arm still throws, so a node type added later
+        /// cannot silently escape the overlay.
+        /// </remarks>
+        public static string Write(SparqlQueryModel query, ILayeredModel layered)
+        {
+            var writer = new SparqlQueryWriter(layered);
             writer.WriteQuery(query);
             return writer._builder.ToString().Trim();
         }
@@ -181,12 +209,20 @@ namespace Semiodesk.Trinity.Query.Sparql
             switch (pattern)
             {
                 case TriplePattern triple:
-                    WriteTerm(triple.Subject);
-                    _builder.Append(' ');
-                    WriteTerm(triple.Predicate);
-                    _builder.Append(' ');
-                    WriteTerm(triple.Object);
-                    _builder.Append(" .");
+                    if (_layered == null)
+                    {
+                        WriteTerm(triple.Subject);
+                        _builder.Append(' ');
+                        WriteTerm(triple.Predicate);
+                        _builder.Append(' ');
+                        WriteTerm(triple.Object);
+                        _builder.Append(" .");
+                    }
+                    else
+                    {
+                        _builder.Append(LayeredModelSparql.Overlay(
+                            _layered, Term(triple.Subject), Term(triple.Predicate), Term(triple.Object)));
+                    }
                     break;
                 case OptionalPattern optional:
                     _builder.Append("OPTIONAL ");
@@ -227,6 +263,16 @@ namespace Semiodesk.Trinity.Query.Sparql
                 default:
                     throw new NotSupportedException($"Unsupported graph pattern: {pattern.GetType().Name}");
             }
+        }
+
+        /// <summary>
+        /// Renders a single term to its SPARQL text, for composing into the overlay macro.
+        /// </summary>
+        private static string Term(SparqlTerm term)
+        {
+            var writer = new SparqlQueryWriter();
+            writer.WriteTerm(term);
+            return writer._builder.ToString();
         }
 
         private void WriteTerm(SparqlTerm term)

--- a/Trinity/Query/SparqlExpressionWriter.cs
+++ b/Trinity/Query/SparqlExpressionWriter.cs
@@ -1,0 +1,161 @@
+// LICENSE:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// AUTHORS:
+//
+//  Moritz Eberl <moritz@semiodesk.com>
+//  Sebastian Faubel <sebastian@semiodesk.com>
+//
+// Copyright (c) Semiodesk GmbH 2026
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using VDS.RDF.Query.Expressions;
+
+namespace Semiodesk.Trinity
+{
+    /// <summary>
+    /// Serializes a SPARQL expression tree back to text.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This exists because dotNetRDF's own serialization is not faithful: it drops the parentheses
+    /// around the operand of a negation, so <c>FILTER(!(?r &lt; 3))</c> comes back as
+    /// <c>FILTER(!?r &lt; 3)</c> — that is <c>(!?r) &lt; 3</c>, a different question — and the result
+    /// still parses, so nothing flags it. <c>SparqlFormatter</c> has the same defect. Parsing is fine;
+    /// the tree is correct, and only writing it out is wrong.
+    /// </para>
+    /// <para>
+    /// The fix is to parenthesise <b>every</b> operator application rather than emit the minimum a
+    /// precedence table would allow. Redundant parentheses cannot change meaning, so correctness needs
+    /// no precedence knowledge at all — which is the point, because a precedence table is exactly the
+    /// kind of thing that is subtly wrong in one corner. Forms that already delimit themselves —
+    /// function calls, aggregates — keep their own shape, with their arguments serialized recursively
+    /// so a bad expression cannot hide inside one.
+    /// </para>
+    /// <para>
+    /// Verified against a corpus of expressions covering negation over comparison, negation over
+    /// conjunction and disjunction, nested negation, <c>IN</c>/<c>NOT IN</c>, <c>REGEX</c>, <c>IF</c>,
+    /// <c>COALESCE</c>, unary minus and arithmetic precedence: faithful in every case, where
+    /// dotNetRDF's serialization is faithful in 17 of 22 and produces text that does not even reparse
+    /// for a doubly nested negation. See <c>SparqlExpressionWriterTest</c>.
+    /// </para>
+    /// </remarks>
+    internal static class SparqlExpressionWriter
+    {
+        /// <summary>
+        /// Writes an expression as SPARQL text.
+        /// </summary>
+        internal static string Write(ISparqlExpression expression)
+        {
+            if (expression == null)
+            {
+                throw new ArgumentNullException(nameof(expression));
+            }
+
+            ISparqlExpression[] arguments = Arguments(expression);
+
+            // A leaf - a variable, an IRI, a literal. Its own ToString is authoritative and there is
+            // nothing nested that could be mis-parenthesised.
+            if (arguments.Length == 0)
+            {
+                return expression.ToString();
+            }
+
+            switch (expression.Type)
+            {
+                case SparqlExpressionType.UnaryOperator:
+                    return "(" + expression.Functor + Write(arguments[0]) + ")";
+
+                case SparqlExpressionType.BinaryOperator:
+                    return "(" + Write(arguments[0]) + " " + expression.Functor + " " + Write(arguments[1]) + ")";
+
+                case SparqlExpressionType.SetOperator:
+                    // ?x IN (a, b, c) - the first argument is the tested value, the rest the set.
+                    return "(" + Write(arguments[0]) + " " + expression.Functor + " (" +
+                           string.Join(", ", arguments.Skip(1).Select(Write)) + "))";
+
+                case SparqlExpressionType.Function:
+                case SparqlExpressionType.Aggregate:
+                    return FunctionName(expression.Functor) + "(" +
+                           string.Join(", ", arguments.Select(Write)) + ")";
+
+                default:
+                    // Primary and anything a future version adds. Refusing here rather than guessing
+                    // keeps an unrecognised form from being written out incorrectly.
+                    throw new NotSupportedException(
+                        $"The SPARQL expression '{expression}' is of kind {expression.Type}, which cannot be " +
+                        "serialized faithfully. It is refused rather than written out approximately, because a " +
+                        "silently altered expression would answer a different question than the one asked.");
+            }
+        }
+
+        /// <summary>
+        /// Renders an expression as a structural signature: operators and nesting, with leaves
+        /// stringified. Two expressions with equal signatures have the same shape.
+        /// </summary>
+        /// <remarks>
+        /// Used to confirm that a re-serialized query still means what it did, which is what turns
+        /// dotNetRDF's serialization defect into a refusal rather than a wrong answer.
+        /// </remarks>
+        internal static string Signature(ISparqlExpression expression)
+        {
+            if (expression == null)
+            {
+                return "(null)";
+            }
+
+            ISparqlExpression[] arguments = Arguments(expression);
+
+            if (arguments.Length == 0)
+            {
+                return expression.ToString();
+            }
+
+            return expression.Functor + "(" + string.Join(",", arguments.Select(Signature)) + ")";
+        }
+
+        /// <summary>
+        /// A function's name is written bare when it is a keyword and bracketed when it is an IRI.
+        /// </summary>
+        private static string FunctionName(string functor)
+        {
+            if (string.IsNullOrEmpty(functor))
+            {
+                return functor;
+            }
+
+            bool isIri = functor.IndexOf(':') > 0 &&
+                         (functor.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
+                          functor.StartsWith("https://", StringComparison.OrdinalIgnoreCase) ||
+                          functor.StartsWith("urn:", StringComparison.OrdinalIgnoreCase));
+
+            return isIri ? "<" + functor + ">" : functor;
+        }
+
+        private static ISparqlExpression[] Arguments(ISparqlExpression expression)
+        {
+            IEnumerable<ISparqlExpression> arguments = expression.Arguments;
+
+            return arguments == null ? new ISparqlExpression[0] : arguments.ToArray();
+        }
+    }
+}

--- a/Trinity/Query/SparqlQuery.cs
+++ b/Trinity/Query/SparqlQuery.cs
@@ -80,7 +80,16 @@ namespace Semiodesk.Trinity
                 {
                     _model = value;
 
-                    if (value is IModelGroup)
+                    if (value is ILayeredModel layered)
+                    {
+                        // A layered model addresses its graphs explicitly with GRAPH, so they must
+                        // be named rather than merged into the default graph by FROM. Merging them
+                        // would union the removals graph back in - the opposite of the intent.
+                        _preprocessor.AddNamedGraph(layered.Baseline.Uri);
+                        _preprocessor.AddNamedGraph(layered.Additions.Uri);
+                        _preprocessor.AddNamedGraph(layered.Removals.Uri);
+                    }
+                    else if (value is IModelGroup)
                     {
                         IModelGroup group = value as IModelGroup;
 
@@ -108,6 +117,17 @@ namespace Semiodesk.Trinity
         /// Indicates if the query result should be expanded using run-time inferencing.
         /// </summary>
         public bool IsInferenceEnabled { get; set; }
+
+        /// <summary>
+        /// Indicates that this query already carries an <see cref="ILayeredModel"/> overlay in its
+        /// graph patterns, and may therefore be run against a layered model.
+        /// </summary>
+        /// <remarks>
+        /// Only Trinity's own overlay-aware read paths set this. A layered model refuses any query
+        /// without it, so caller-supplied SPARQL - or a read path added later that forgets to apply
+        /// the overlay - fails loudly instead of silently returning triples staged for removal.
+        /// </remarks>
+        internal bool IsOverlayApplied { get; set; }
 
         #endregion
 

--- a/Trinity/Query/SparqlSerializer.cs
+++ b/Trinity/Query/SparqlSerializer.cs
@@ -284,6 +284,13 @@ namespace Semiodesk.Trinity
                 return "";
             }
 
+            if (model is ILayeredModel layered)
+            {
+                // FROM would merge the three graphs into the default graph, which is union - the
+                // overlay needs them addressable by name instead.
+                return LayeredModelSparql.NamedDatasetClause(layered);
+            }
+
             if (model is IModelGroup)
             {
                 return GenerateDatasetClause(model as IModelGroup);
@@ -417,8 +424,16 @@ namespace Semiodesk.Trinity
             string from = GenerateDatasetClause(model);
             string where = query.GetRootGraphPattern();
 
+            // The inner pattern already carries the overlay - it came from the query root graph
+            // pattern - but the outer triple pattern this method adds does not, and unguarded it
+            // would fetch the paged resources triples straight from the baseline, removals
+            // included. Wrap it too.
+            string outer = model is ILayeredModel layeredModel
+                ? LayeredModelSparql.Overlay(layeredModel, variable, "?p", "?o")
+                : string.Format("{0} ?p ?o", variable);
+
             StringBuilder resultBuilder = new StringBuilder();
-            resultBuilder.AppendFormat("SELECT {0} ?p ?o {1} WHERE {{ {0} ?p ?o {{", variable, from);
+            resultBuilder.AppendFormat("SELECT {0} ?p ?o {1} WHERE {{ {2} {{", variable, from, outer);
             resultBuilder.AppendFormat("SELECT DISTINCT {0} WHERE {{ {1} }}", variable, where);
 
             if (offset != -1)

--- a/Trinity/Stores/StoreExtensions.cs
+++ b/Trinity/Stores/StoreExtensions.cs
@@ -37,6 +37,109 @@ namespace Semiodesk.Trinity
     public static class StoreExtensions
     {
         /// <summary>
+        /// Creates a read-only view over three named graphs with working-copy semantics: reads see
+        /// <c>(baseline - removals) union additions</c> while the baseline graph itself stays
+        /// untouched.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This is an extension method rather than a member of <see cref="IStore"/> deliberately. A
+        /// layered model needs nothing store-specific beyond <c>ExecuteQuery</c> and
+        /// <c>GetModel</c>, so putting it here avoids a breaking change to the interface every
+        /// custom backend implements - and avoids reproducing the empty-group bug that the
+        /// per-store <c>CreateModelGroup(params IModel[])</c> overrides still carry.
+        /// </para>
+        /// <para>
+        /// The three graphs need not exist yet; an absent graph simply contributes nothing, so a
+        /// view with empty additions and removals reads exactly like the baseline.
+        /// </para>
+        /// </remarks>
+        /// <param name="store">The store holding all three graphs.</param>
+        /// <param name="baseline">URI of the unchanged graph read through the view.</param>
+        /// <param name="additions">URI of the graph holding triples staged for addition.</param>
+        /// <param name="removals">URI of the graph holding triples staged for removal.</param>
+        /// <exception cref="NotSupportedException">
+        /// Thrown if the store cannot honour the overlay - see <see cref="CanHostLayeredModel"/>.
+        /// </exception>
+        /// <exception cref="ArgumentException">Thrown if any two URIs name the same graph.</exception>
+        public static ILayeredModel CreateLayeredModel(this IStore store, Uri baseline, Uri additions, Uri removals)
+        {
+            if (store == null) throw new ArgumentNullException(nameof(store));
+            if (baseline == null) throw new ArgumentNullException(nameof(baseline));
+            if (additions == null) throw new ArgumentNullException(nameof(additions));
+            if (removals == null) throw new ArgumentNullException(nameof(removals));
+
+            if (!CanHostLayeredModel(store))
+            {
+                throw new NotSupportedException(
+                    store.GetType().Name + " cannot host a layered model: it discards the dataset clause of " +
+                    "every query it runs, so the overlay's graph scoping would be lost and reads would " +
+                    "silently include triples staged for removal.");
+            }
+
+            return new LayeredModel(store, store.GetModel(baseline), store.GetModel(additions), store.GetModel(removals));
+        }
+
+        /// <summary>
+        /// Creates a read-only layered view over three existing models of the same store.
+        /// </summary>
+        /// <inheritdoc cref="CreateLayeredModel(IStore, Uri, Uri, Uri)" path="/remarks" />
+        public static ILayeredModel CreateLayeredModel(this IStore store, IModel baseline, IModel additions, IModel removals)
+        {
+            if (store == null) throw new ArgumentNullException(nameof(store));
+            if (baseline == null) throw new ArgumentNullException(nameof(baseline));
+            if (additions == null) throw new ArgumentNullException(nameof(additions));
+            if (removals == null) throw new ArgumentNullException(nameof(removals));
+
+            RequireSameStore(store, baseline, nameof(baseline));
+            RequireSameStore(store, additions, nameof(additions));
+            RequireSameStore(store, removals, nameof(removals));
+
+            return store.CreateLayeredModel(baseline.Uri, additions.Uri, removals.Uri);
+        }
+
+        /// <summary>
+        /// Rejects a model that belongs to a different store.
+        /// </summary>
+        /// <remarks>
+        /// The overlay is a single SPARQL query over a single dataset, so a graph in another store is
+        /// simply not in scope: <c>GRAPH &lt;g&gt;</c> would match nothing there. Without this check the
+        /// view answers from whichever graphs the executing store happens to have and silently ignores
+        /// the rest - returning triples staged for removal, or dropping the baseline entirely,
+        /// depending on which store executes. That is the one failure this design must not have, so it
+        /// is refused at construction.
+        /// </remarks>
+        private static void RequireSameStore(IStore store, IModel model, string parameterName)
+        {
+            // Every IStore.GetModel implementation returns the concrete Model, so this covers every
+            // model a caller can actually obtain.
+            if (model is Model concrete && !ReferenceEquals(concrete.Store, store))
+            {
+                throw new NotSupportedException(
+                    "The " + parameterName + " model <" + model.Uri + "> belongs to a different store. A layered " +
+                    "model is evaluated as one SPARQL query over one dataset, so all three graphs must live in the " +
+                    "same store. To overlay a change held elsewhere - for example an in-memory pending change over a " +
+                    "Virtuoso baseline - copy the additions and removals graphs into the store that holds the " +
+                    "baseline, or merge the layers client-side. See doc/adr/0041-layered-read-views.md.");
+            }
+        }
+
+        /// <summary>
+        /// Indicates whether a store can answer layered reads correctly.
+        /// </summary>
+        /// <remarks>
+        /// Only <c>SparqlEndpointStore</c> cannot: it parses every query and calls
+        /// <c>ClearDefaultGraphs()</c>/<c>ClearNamedGraphs()</c> before sending it, which strips the
+        /// <c>FROM NAMED</c> clause the overlay's <c>GRAPH</c> blocks rely on. It also has no
+        /// <c>ExecuteNonQuery</c>, so a change could not be staged there in the first place. Rather
+        /// than add a capability model (ADR-0022 declines one), this is a single negative check.
+        /// </remarks>
+        internal static bool CanHostLayeredModel(IStore store)
+        {
+            return !(store is Store.SparqlEndpointStore);
+        }
+
+        /// <summary>
         /// Reads one or more RDF files into named graphs of the store, inferring the serialization
         /// format from each file's extension (<c>.n3</c>, <c>.trig</c>, <c>.ttl</c>, <c>.nt</c>,
         /// otherwise RDF/XML).

--- a/doc/adr/0019-models-are-named-graphs-modelgroups.md
+++ b/doc/adr/0019-models-are-named-graphs-modelgroups.md
@@ -27,6 +27,15 @@ See `Trinity/Model/Model.cs`, `Trinity/Model/IModelGroup.cs`, `Trinity/Model/Mod
 - Note the known Fuseki `CreateModelGroup(params IModel[])` bug (builds an empty group),
   tracked in [0009](0009-supported-store-backends.md).
 
+## Notes added later
+- A `ModelGroup` can only **union**: its dataset clause is one `FROM` per member, and SPARQL has no
+  inverse of that. Subtracting a graph needs the guard inside the graph pattern, which is a different
+  abstraction — see [0041](0041-layered-read-views.md), which adds `ILayeredModel` as a sibling rather
+  than extending this one.
+- `IModelGroup.DefaultModel` is **dead**: declared on the interface, auto-implemented on `ModelGroup`,
+  and never read or assigned anywhere in the repository. It records an intent that was never wired up.
+  Removing it is a breaking change to a public interface and has been left for its own change.
+
 ## Related
 - [0008](0008-store-model-abstraction.md), [0009](0009-supported-store-backends.md),
-  [0024](0024-sparql-reuses-registered-prefixes.md)
+  [0024](0024-sparql-reuses-registered-prefixes.md), [0041](0041-layered-read-views.md)

--- a/doc/adr/0041-layered-read-views.md
+++ b/doc/adr/0041-layered-read-views.md
@@ -1,0 +1,312 @@
+# 0041. Layered read views: baseline + additions − removals
+
+Date: 2026-08-19
+
+## Status
+Accepted
+
+## Context
+
+Trinity can union named graphs but it cannot subtract from them. `IModelGroup` derives a cached
+dataset clause of one `FROM <uri>` per member (`ModelGroup.UpdateDatasetClause` →
+`SparqlSerializer.GenerateDatasetClause`), and `FROM` is set union — SPARQL offers no inverse. So a
+model group can express "read these graphs together" and nothing else.
+
+What was needed is git-working-tree semantics over RDF. An agent (or a user) works against a large
+`baseline` graph and holds its pending work as an `additions` and a `removals` graph. Everything
+reading through the view should see the baseline as if the pending change had been applied —
+**deletions included** — while the baseline itself stays untouched until the change is accepted or
+discarded.
+
+The requirement that shapes the design is that mapped-object reads honour it: if `GetResource`,
+`GetResource<T>`, `GetResources<T>` and `ContainsResource` apply the overlay, code written against
+`IModel` needs no change at all.
+
+Subtraction cannot be added by extending the dataset clause. It has to reach the **graph pattern** of
+every query the view answers — which is precisely the part a model group does not own for arbitrary
+queries. And the failure mode is silent: a read path that ignores the removals graph returns triples
+the caller believes are deleted, with nothing to signal it.
+
+## Decision
+
+### A sibling abstraction, not an extension of model groups
+
+`ILayeredModel : IModel` with `Baseline`, `Additions` and `Removals`, implemented by `LayeredModel`.
+It is deliberately **not** an `IModelGroup`:
+
+- A group is an `ISet<IModel>` of interchangeable members that are merely unioned. The three graphs
+  here have distinct roles, so `Add`/`Remove` have no meaning for them.
+- Keeping the types apart means the existing union-only code paths — the `is IModelGroup` branches in
+  the `SparqlQuery.Model` setter and in `GenerateDatasetClause`, and GraphDB's inference path, which
+  rebuilds a query's dataset as a `ModelGroup` — cannot mistake a layered view for a union. The
+  `IModelGroup` contract is untouched and no existing consumer changes behaviour.
+
+Created by an extension method, `IStore.CreateLayeredModel(...)` in `StoreExtensions`, rather than a
+new `IStore` member. A layered model needs nothing store-specific beyond `ExecuteQuery`/`GetModel`, so
+this avoids a breaking change to the interface every custom backend implements — and avoids
+reproducing the `CreateModelGroup(params IModel[])` empty-group bug that three stores still carry.
+
+### Semantics: additions win
+
+`effective = (baseline − removals) ∪ additions`. A triple in both `additions` and `removals` is
+**visible**. This is what makes an ordinary edit — remove the old value, add the new one — behave the
+way callers expect, and it means staging an addition always makes it readable. The alternative reading
+of the formula, `(baseline ∪ additions) − removals`, would let a stale removal mask a fresh addition.
+
+### One overlay macro, four consumers
+
+`LayeredModelSparql` is the single source of truth. Every triple pattern becomes
+
+```sparql
+{ { GRAPH <baseline>  { S P O } <guard> }
+  UNION
+  { GRAPH <additions> { S P O } } }
+```
+
+with the guard applying **only** to the baseline branch — that asymmetry is what makes additions win.
+The dataset clause is `FROM NAMED` for all three graphs, never bare `FROM`, because the overlay
+addresses them with `GRAPH` and merging them would union the removals graph straight back in.
+
+Used by exactly four call sites: `LayeredModel`'s own templates, `SparqlQueryWriter` (LINQ),
+`SparqlSerializer.GenerateDatasetClause` and `SparqlSerializer.SerializeOffsetLimit`.
+
+### The guard primitive is chosen for correctness, not speed
+
+**`MINUS` when the pattern binds at least one variable; `FILTER NOT EXISTS` when it is fully ground.**
+
+`MINUS` is much the faster primitive — engines evaluate it as an anti-join rather than a per-row
+nested-loop probe, worth 18x → 1.5x on an unselective scan. But SPARQL `MINUS` removes nothing when
+the two sides share no variables, and a fully ground triple pattern has none. There, a `MINUS` guard
+**silently fails to subtract**. Measured, with a triple present in both `baseline` and `removals`:
+
+| | in-memory | Virtuoso | GraphDB |
+|---|---|---|---|
+| via `FILTER NOT EXISTS` | subtracted | subtracted | subtracted |
+| via `MINUS` | **not subtracted** | subtracted | **not subtracted** |
+
+dotNetRDF and GraphDB are spec-correct; Virtuoso is the deviation. A ground pattern is a single
+existence check, so `FILTER NOT EXISTS` costs nothing there and is the only safe choice.
+`LayeredModelSparqlTest.MinusWouldNotSubtractAGroundPattern` pins the trap so the rule cannot be
+simplified away later.
+
+### Emission rules that are requirements, not optimisations
+
+Two further rules came out of measurement, and getting either wrong is a four-orders-of-magnitude
+regression rather than a wrong answer:
+
+1. **Bind a known subject with `VALUES ?s { <u> }` before the overlay**, never as a trailing
+   `FILTER (?s = <u>)`. Neither the in-memory engine nor GraphDB pushes a filter into a `UNION`
+   containing an anti-join — 15x and 38x respectively, against ~1.0x for the `VALUES` form.
+2. **Emit selective patterns before the wildcard `?s ?p ?o`.** An engine that cannot reorder joins
+   across the overlay's `UNION` evaluates patterns as written, so a leading wildcard materialises the
+   whole effective graph before applying any constraint: **61,000x** on the in-memory engine.
+   `SparqlQueryTranslator.BuildResourceQuery` previously emitted the wildcard *first*, so this
+   required changing it — the naive rewrite lands exactly on that case. Pattern order inside a basic
+   graph pattern is semantically irrelevant, so the change is safe for plain models, which reorder
+   freely.
+
+A third constraint is structural: resource materialization refuses any query for which
+`ISparqlQuery.ProvidesStatements()` is false, and that is decided by a token-level heuristic wanting
+exactly three same-ordered global variables. The overlay wraps the patterns in nesting, `UNION` and
+`VALUES`, so this is easy to break unnoticed; `EveryEmittedShapeProvidesStatements` asserts it for
+every shape the implementation emits.
+
+### LINQ is honoured natively; caller SPARQL is rewritten
+
+LINQ is honoured because Trinity **owns** its LINQ AST. `SparqlQueryWriter.WritePattern` switches over
+eight node types with `default: throw`. Only `TriplePattern` resolves against data — groups,
+`OPTIONAL`, `UNION`, `MINUS` and sub-selects merely contain patterns, and `BIND`/`VALUES` touch no
+graph — so wrapping **one case arm** is exhaustive by construction, and a node type added later throws
+rather than leaking.
+
+Caller-supplied SPARQL is handled by `OverlayQueryRewriter`, which works on the **parse tree** rather
+than the text. That is what makes it tractable: the abbreviations that would defeat a token-level
+rewrite — predicate-object lists (`;`), object lists (`,`), blank-node property lists (`[ ]`) — are
+already expanded into plain triple patterns by the time the parser is done. It is a **whitelist**: every
+pattern kind and every filter expression must be recognised as safe, and anything else throws with the
+reason.
+
+Accepted and covered by the corpus in `LayeredModelQueryCorpusTest`: basic graph patterns, multiple
+joined patterns, `FILTER` (numeric, string via `str()`, negated equality), `;` and `,` lists,
+IRI-valued objects, `OPTIONAL`, `UNION`, `MINUS`, sub-`SELECT`, `VALUES`, `BIND`, `DISTINCT`,
+`ORDER BY`/`LIMIT`/`OFFSET`, `SELECT *`, aggregates with `GROUP BY`/`HAVING`, `ASK`, `IN`/`NOT IN`,
+nested function calls, arithmetic precedence, and negation wrapped around a comparison, conjunction or
+disjunction.
+
+Refused, each detected from the parse tree rather than guessed:
+
+| Form | Why |
+|---|---|
+| property path (`/`, `+`, `*`, …) | walks intermediate nodes that must themselves resolve against the effective graph, and a transitive path has no fixed expansion |
+| explicit `GRAPH` block | a view is itself built from three graphs; naming one reads past the overlay, and `GRAPH ?g` exposes the removals graph as ordinary data |
+| `SERVICE` | the remote endpoint knows nothing of the overlay |
+| `CONSTRUCT` | its template describes triples to build, not to match, so the overlay must not be applied there |
+| `DESCRIBE` | the store chooses the triples; there is no pattern to rewrite |
+| `FILTER EXISTS` / `NOT EXISTS` | not a child pattern but an `ExistsFunction` inside the filter expression, whose nested pattern would read the baseline directly |
+| a negation inside `HAVING` or a projected expression | dotNetRDF mangles it and those two are not re-emitted by the rewriter — see below |
+| a query with its own `FROM` / `FROM NAMED` | the view defines the dataset, so a query cannot also choose one |
+
+### Expressions are serialized by Trinity, not by dotNetRDF
+
+dotNetRDF's expression serialization is **not faithful**: it drops the parentheses around the operand of
+a negation, so `!(?r < 3)` comes back as `!?r < 3` — that is `(!?r) < 3`, a different question — and the
+result still parses, so nothing flags it. `SparqlFormatter` has the same defect, and
+`!(!(?r < 3))` produces text that does not re-parse at all. Parsing is fine; the tree is correct. Only
+writing it out is wrong.
+
+`SparqlExpressionWriter` therefore serializes expressions itself, and is used for every `FILTER` and
+`BIND` the rewrite emits. It **parenthesises every operator application** rather than emitting the
+minimum a precedence table would allow: redundant parentheses cannot change meaning, so correctness
+needs no precedence knowledge — and a precedence table is exactly the kind of thing that is subtly wrong
+in one corner. Self-delimiting forms (function calls, aggregates) keep their own shape, with arguments
+serialized recursively so a bad expression cannot hide inside one. Measured over a 22-expression corpus:
+faithful in 22/22, where dotNetRDF is faithful in 17/22.
+
+**Two things it cannot repair, only detect.** `HAVING` and projected expressions are not re-emitted by
+the rewriter — they come from dotNetRDF's serialization of the query head and solution modifiers, which
+is reused verbatim precisely so that projection, `GROUP BY` and `ORDER BY` need not be reimplemented. A
+negation inside one of those is mangled exactly as it is inside a filter, so such a query is **refused**
+with a suggested rephrasing. Extending the writer to the head would lift that restriction and is a
+reasonable follow-up; it was not worth reimplementing projection emission for.
+
+**The rewrite is verified, not trusted.** The result is re-parsed and everything that had to be
+preserved is compared structurally against the original: query form, `LIMIT`, `OFFSET`, projected
+variables, `HAVING`, projected expressions, and every filter and `BIND` expression. A mismatch throws
+rather than executes.
+
+That check earns its keep. It caught two defects during development that no test of the *output* would
+have found: filters and `BIND`s held in `GraphPattern.UnplacedFilters` / `UnplacedAssignments` rather
+than among a group's triple patterns were being dropped from the rewrite entirely — a silently lost
+constraint — and the same filter reachable through both `Filter` and `UnplacedFilters` was being
+double-counted. Filter signatures are compared as a **distinct set** for that reason; a repeated filter
+is idempotent, so a count difference carries no meaning. Comparing them at all is only sound because a
+caller's own `EXISTS`/`NOT EXISTS` is refused, which is what lets the overlay's own `FILTER NOT EXISTS`
+guards be excluded from the comparison unambiguously.
+
+### Parameters, and a deferred optimisation
+
+The strict SPARQL parser rejects Trinity's `@parameter` syntax
+(`Unexpected Character (Code 64) @ encountered`), so the rewrite runs on `ISparqlQuery.ToString()`,
+after every `Bind()` call has been substituted.
+
+**The accepted cost:** a caller query is parsed, walked, re-emitted and re-parsed on *every* execution.
+For a query executed in a loop with different parameter values, that work is repeated each time even
+though only the bound values changed. This is a deliberate trade — correctness and a small
+implementation over speed — and it affects only caller-supplied SPARQL; the mapped reads and LINQ build
+their queries with the overlay already in place and never go near the rewriter.
+
+**The optimisation, when it matters:** substitute each `@parameter` with a placeholder that *is* legal
+SPARQL — an IRI such as `<urn:trinity:param:subject>` — before parsing, rewrite once, cache the result,
+and map the placeholders back to `@parameter` in the output so Trinity's own preprocessor can keep
+binding values into it. That makes the rewrite a per-query-shape cost instead of a per-execution one,
+and needs no change to either parser. It is purely lexical, and the round-trip verification would still
+apply to the cached form. Worth doing if profiling ever shows caller queries on a layered view are hot;
+not worth doing before that.
+
+A related consequence worth knowing: Trinity's own tokeniser accepts a wider extended syntax than the
+strict parser, so a query may be accepted by a plain `Model` and refused by a view.
+
+### Read-only, and no inferencing
+
+Every mutating member throws, as `ModelGroup` does. Stage a change by writing to `Additions` and
+`Removals`, which are ordinary models. (Routing writes automatically would mean splitting the
+`WITH <graph> DELETE {…} INSERT {…}` delta that `StoreBase.TryBuildDeltaUpdate` builds so its DELETE
+half becomes an INSERT into the removals graph — a new write path in every store, deferred.)
+
+`inferenceEnabled: true` throws. Every store's inference path defeats the overlay — GraphDB rebuilds
+the dataset as a plain model group, Virtuoso answers with a bare `DESCRIBE` that cannot carry a guard —
+and entailment over a subtracted graph is not something any store reasoner defines.
+
+`SparqlEndpointStore` cannot host a layered model at all: it calls `ClearDefaultGraphs()` /
+`ClearNamedGraphs()` on every query before sending it, stripping the `FROM NAMED` the overlay relies
+on. `CreateLayeredModel` refuses it rather than adding a capability model (ADR-0022 declines one).
+
+### All three graphs must live in one store
+
+The overlay is **one SPARQL query over one dataset**, so a graph held in a different store is simply
+not in scope — `GRAPH <g>` matches nothing there. Composing a view across stores (say a Virtuoso
+baseline with an in-memory pending change) was measured, and it fails *silently* in either direction:
+
+| Arrangement | Result |
+|---|---|
+| Virtuoso executes, layers in memory | returns the triple staged for **removal**; no exception |
+| in-memory executes, baseline in Virtuoso | **drops the baseline entirely**; no exception |
+
+Both are precisely the failure this design exists to prevent, so it is made unrepresentable rather
+than documented: `LayeredModel`'s constructor is **internal** and the factory resolves all three URIs
+against one store, while the `IModel` overload rejects a model belonging to another store
+(`StoreExtensions.RequireSameStore`). Every `IStore.GetModel` returns the concrete `Model`, so the
+check covers every model a caller can obtain.
+
+To overlay a change that lives elsewhere, either copy the additions and removals graphs into the store
+holding the baseline — they are small by nature, being one pending change — or merge the layers
+client-side, which is tractable for the subject-bound reads but not for LINQ selection or type scans.
+Federating with SPARQL `SERVICE` is possible in principle (dotNetRDF exposes
+`VDS.RDF.Query.Algebra.Service`) but would ship a subquery per pattern and defeat the guard pushdown
+the measured numbers depend on. None of that is in v1.
+
+### Coverage
+
+| Read path | v1 |
+|---|---|
+| `GetResource` (all 5 overloads), `GetResources(uris, type)`, `GetResources<T>()` | honoured |
+| `ContainsResource`, `IsEmpty` | honoured |
+| `AsQueryable<T>()` — every form the provider supports | honoured |
+| Lazy loading of linked resources | honoured |
+| Result `Count()` and paged `GetResources(offset, limit)` | honoured |
+| `ExecuteQuery(ISparqlQuery)`, `GetResources(query)`, `GetResources<T>(query)`, `GetBindings` | **rewritten**, or throws for a form outside the whitelist |
+| any read with `inferenceEnabled: true` | **throws** |
+| all mutators, `ExecuteUpdate`, `Read`, `Write`, `Clear`, `BeginTransaction` | **throws** |
+| construction over `SparqlEndpointStore` | **throws** |
+
+Note the deliberate asymmetry: `GetResources<T>()` and `AsQueryable<T>()` cover the mapped cases while
+the `ISparqlQuery` overloads throw.
+
+## Consequences
+
+**Performance is a non-issue on the server stores and acceptable in memory.** Ratios of layered to
+plain reads at 1,000,000 baseline triples, with ~100 staged additions and ~100 staged removals:
+
+| Read shape | in-memory | Virtuoso | GraphDB |
+|---|---|---|---|
+| `GetResource` (subject-bound) | 1.55x | 1.06x | 0.86x |
+| LINQ `Where` (selective) | 3.00x | 1.03x | 1.55x |
+| `GetResources<T>()` (unselective scan) | 1.50x | 1.05x | 1.14x |
+
+**The cheap alternative was measured and rejected.** `COPY <baseline> TO <working>` works on all three
+stores — this contradicts the initial expectation that Virtuoso's `SPARQL { … }` update wrapper would
+reject a graph-management form; it does not. But copying costs 3.9–6.0 s and a full duplicate of the
+baseline *per working copy* at 1M triples, against a ~1x read cost, and accepting the change then needs
+an O(baseline) diff instead of reading an O(changes) delta. For the intended use — a small pending
+change against a large baseline — the overlay wins. A `CopyModel` primitive remains worth having for
+long-lived, write-heavy working copies; it is not this feature.
+
+**Costs and limits.**
+- Caller-supplied SPARQL against a layered model is a hard error, which will surprise anyone used to
+  `ModelGroup.ExecuteQuery`. That is the intended trade: loud over silently wrong.
+- No inferencing through a view.
+- The overlay defeats join reordering on engines that cannot see through `UNION`, so emission order is
+  load-bearing. The two ordering rules are commented at their emission sites and asserted by tests;
+  a future refactor that "tidies" them will regress performance by orders of magnitude without
+  changing any result.
+- `LayeredModel` duplicates a good deal of `ModelGroup`'s interface boilerplate. Extracting a shared
+  read-only `IModel` base was considered and skipped: `ModelGroup` is load-bearing for existing
+  consumers and this release favours not touching it.
+
+**Explicitly out of scope for v1:** branching, merge, conflict detection, history, nested or stacked
+overlays, and views spanning more than one store. One baseline, one additions graph, one removals
+graph, one store.
+
+**Verified:** in-memory 542 passed / 3 pre-existing failures / 7 skipped; Virtuoso 175 passed / 4
+pre-existing failures / 1 skipped; GraphDB 182 passed / 4 pre-existing failures / 1 skipped. In each
+case the failure set is byte-identical to the same suite at the previous commit, and the delta is
+exactly the new tests (+27 in-memory, +16 per store). Fuseki is not covered: its suite is a
+hand-written non-generic copy and the backend is 4/86 on an upstream `FusekiConnector` bug (ADR-0036).
+
+## Related
+- [0019](0019-models-are-named-graphs-modelgroups.md) — models are named graphs; model groups union them
+- [0016](0016-resource-centric-not-triple-centric.md) — resource-centric reads are what the view has to serve
+- [0022](0022-store-capabilities-and-istore-extension.md) — no capability model; hence the single negative store check
+- [0029](0029-resource-commit-rollback-change-tracking.md), [0039](0039-resource-write-semantics.md) — the write path a writable v2 would have to split
+- [0037](0037-linq-provider-rebuild.md) — the owned LINQ AST that makes the LINQ rewrite exhaustive
+- `Trinity/Model/ILayeredModel.cs`, `Trinity/Model/LayeredModel.cs`, `Trinity/Query/LayeredModelSparql.cs`

--- a/doc/adr/0041-layered-read-views.md
+++ b/doc/adr/0041-layered-read-views.md
@@ -246,9 +246,14 @@ strict parser, so a query may be accepted by a plain `Model` and refused by a vi
 ### Read-only, and no inferencing
 
 Every mutating member throws, as `ModelGroup` does. Stage a change by writing to `Additions` and
-`Removals`, which are ordinary models. (Routing writes automatically would mean splitting the
-`WITH <graph> DELETE {…} INSERT {…}` delta that `StoreBase.TryBuildDeltaUpdate` builds so its DELETE
-half becomes an INSERT into the removals graph — a new write path in every store, deferred.)
+`Removals`, which are ordinary models.
+
+*Correction, added later:* this originally justified read-only by claiming that routing writes would mean
+"a new write path in every store". That is wrong. `SparqlSerializer.TrySerializeResourceDelta` is
+store-independent and already shared by all four write paths (ADR-0039), so staging is one update builder
+that routes its two output lists to different graphs — no per-store work. Read-only remains the right
+call for this release, but on the grounds of scope rather than cost. See
+[0042](0042-staged-writes-and-accept.md).
 
 `inferenceEnabled: true` throws. Every store's inference path defeats the overlay — GraphDB rebuilds
 the dataset as a plain model group, Virtuoso answers with a bare `DESCRIBE` that cannot carry a guard —

--- a/doc/adr/0041-layered-read-views.md
+++ b/doc/adr/0041-layered-read-views.md
@@ -148,7 +148,7 @@ Refused, each detected from the parse tree rather than guessed:
 
 | Form | Why |
 |---|---|
-| property path (`/`, `+`, `*`, …) | walks intermediate nodes that must themselves resolve against the effective graph, and a transitive path has no fixed expansion |
+| property path — see below | the unbounded forms cannot be supported at all; the bounded forms are simply not implemented yet |
 | explicit `GRAPH` block | a view is itself built from three graphs; naming one reads past the overlay, and `GRAPH ?g` exposes the removals graph as ordinary data |
 | `SERVICE` | the remote endpoint knows nothing of the overlay |
 | `CONSTRUCT` | its template describes triples to build, not to match, so the overlay must not be applied there |
@@ -157,6 +157,30 @@ Refused, each detected from the parse tree rather than guessed:
 | a blank node, including the `[ … ]` property-list form | the overlay repeats each pattern across three basic graph patterns, and SPARQL forbids a blank-node label appearing in more than one of them |
 | a negation inside `HAVING`, a projected expression, `GROUP BY` or `ORDER BY` | dotNetRDF mangles it and none of those four are re-emitted by the rewriter — see below |
 | a query with its own `FROM` / `FROM NAMED` | the view defines the dataset, so a query cannot also choose one |
+
+### Why property paths are refused, and which of them could not be otherwise
+
+The **unbounded** forms — `p+`, `p*`, `p{n,}` — cannot be supported, and the reason is sharper than
+"paths are hard": **transitive closure does not distribute over the union of the layers.** Measured —
+with `a p b` in the baseline and `b p c` in the additions, so the chain crosses the layer boundary:
+
+| evaluation | result |
+|---|---|
+| closure over the merged graph (correct) | `b, c` |
+| closure inside each graph, then unioned | `b` |
+
+The chain exists in the effective graph but in neither layer alone, so the path cannot be pushed inside
+the overlay's `GRAPH` blocks. And being unbounded it has no finite expansion into triple patterns to
+push the overlay into instead. Evaluating one correctly would mean materializing the effective graph
+first — a write, and O(baseline) per query.
+
+The **bounded** forms are a different matter, and are refused only because the expansion is unwritten:
+`^p` is a subject/object swap, `p1/p2` expands into two patterns joined by a fresh variable, `p1|p2`
+into a `UNION`, and `!p` into a variable predicate with a filter. Each then goes through the overlay one
+pattern at a time; the sequence case was verified to give the same answer as the native path. The
+refusal message distinguishes the two groups so a caller can tell which side of the line they are on.
+Implementing the bounded forms is a worthwhile follow-up — the original blanket claim that paths "cannot
+be rewritten" was too broad.
 
 ### Expressions are serialized by Trinity, not by dotNetRDF
 

--- a/doc/adr/0041-layered-read-views.md
+++ b/doc/adr/0041-layered-read-views.md
@@ -60,12 +60,23 @@ of the formula, `(baseline ∪ additions) − removals`, would let a stale remov
 ```sparql
 { { GRAPH <baseline>  { S P O } <guard> }
   UNION
-  { GRAPH <additions> { S P O } } }
+  { GRAPH <additions> { S P O }
+    FILTER NOT EXISTS { GRAPH <baseline> { S P O } FILTER NOT EXISTS { GRAPH <removals> { S P O } } } } }
 ```
 
-with the guard applying **only** to the baseline branch — that asymmetry is what makes additions win.
-The dataset clause is `FROM NAMED` for all three graphs, never bare `FROM`, because the overlay
-addresses them with `GRAPH` and merging them would union the removals graph straight back in.
+The guard applies **only** to the baseline branch — that asymmetry is what makes additions win. The
+dataset clause is `FROM NAMED` for all three graphs, never bare `FROM`, because the overlay addresses
+them with `GRAPH` and merging them would union the removals graph straight back in.
+
+**The two branches are disjoint by construction, and that is load-bearing.** SPARQL `UNION` is a
+**bag** union, so overlapping branches yield *two* solutions for a triple present in both the baseline
+and the additions — inflated `COUNT`s and duplicated rows — where the view promises the *set*
+`(baseline − removals) ∪ additions`. Re-adding a value that is already there is precisely what
+"additions win" invites a caller to do, so the overlap is the ordinary case, not an exotic one. The
+additions branch therefore excludes whatever the baseline branch already produced. Its inner guard is
+always `FILTER NOT EXISTS`, never `MINUS`: nested inside `NOT EXISTS` the pattern is tested for
+existence rather than joined, so a `MINUS` with no shared variables would remove nothing and invert the
+answer for a triple present in all three graphs.
 
 Used by exactly four call sites: `LayeredModel`'s own templates, `SparqlQueryWriter` (LINQ),
 `SparqlSerializer.GenerateDatasetClause` and `SparqlSerializer.SerializeOffsetLimit`.
@@ -143,7 +154,8 @@ Refused, each detected from the parse tree rather than guessed:
 | `CONSTRUCT` | its template describes triples to build, not to match, so the overlay must not be applied there |
 | `DESCRIBE` | the store chooses the triples; there is no pattern to rewrite |
 | `FILTER EXISTS` / `NOT EXISTS` | not a child pattern but an `ExistsFunction` inside the filter expression, whose nested pattern would read the baseline directly |
-| a negation inside `HAVING` or a projected expression | dotNetRDF mangles it and those two are not re-emitted by the rewriter — see below |
+| a blank node, including the `[ … ]` property-list form | the overlay repeats each pattern across three basic graph patterns, and SPARQL forbids a blank-node label appearing in more than one of them |
+| a negation inside `HAVING`, a projected expression, `GROUP BY` or `ORDER BY` | dotNetRDF mangles it and none of those four are re-emitted by the rewriter — see below |
 | a query with its own `FROM` / `FROM NAMED` | the view defines the dataset, so a query cannot also choose one |
 
 ### Expressions are serialized by Trinity, not by dotNetRDF
@@ -162,12 +174,13 @@ in one corner. Self-delimiting forms (function calls, aggregates) keep their own
 serialized recursively so a bad expression cannot hide inside one. Measured over a 22-expression corpus:
 faithful in 22/22, where dotNetRDF is faithful in 17/22.
 
-**Two things it cannot repair, only detect.** `HAVING` and projected expressions are not re-emitted by
-the rewriter — they come from dotNetRDF's serialization of the query head and solution modifiers, which
-is reused verbatim precisely so that projection, `GROUP BY` and `ORDER BY` need not be reimplemented. A
-negation inside one of those is mangled exactly as it is inside a filter, so such a query is **refused**
-with a suggested rephrasing. Extending the writer to the head would lift that restriction and is a
-reasonable follow-up; it was not worth reimplementing projection emission for.
+**Four things it cannot repair, only detect.** `HAVING`, projected expressions, `GROUP BY` and
+`ORDER BY` are not re-emitted by the rewriter — they come from dotNetRDF's serialization of the query
+head and solution modifiers, which is reused verbatim precisely so that projection, grouping and
+ordering need not be reimplemented. A negation inside any of them is mangled exactly as it is inside a
+filter, so such a query is **refused** with a suggested rephrasing. Extending the writer to the head
+would lift that restriction and is a reasonable follow-up; it was not worth reimplementing projection
+emission for.
 
 **The rewrite is verified, not trusted.** The result is re-parsed and everything that had to be
 preserved is compared structurally against the original: query form, `LIMIT`, `OFFSET`, projected
@@ -264,14 +277,21 @@ the `ISparqlQuery` overloads throw.
 
 ## Consequences
 
-**Performance is a non-issue on the server stores and acceptable in memory.** Ratios of layered to
-plain reads at 1,000,000 baseline triples, with ~100 staged additions and ~100 staged removals:
+**Performance is a non-issue on the server stores and acceptable in memory.** Measured through the
+production code path at 1,000,000 baseline triples, with ~100 staged additions and ~100 staged removals:
 
-| Read shape | in-memory | Virtuoso | GraphDB |
+| Read | in-memory | Virtuoso | GraphDB |
 |---|---|---|---|
-| `GetResource` (subject-bound) | 1.55x | 1.06x | 0.86x |
-| LINQ `Where` (selective) | 3.00x | 1.03x | 1.55x |
-| `GetResources<T>()` (unselective scan) | 1.50x | 1.05x | 1.14x |
+| `GetResource` (subject-bound) | 1.31x | 0.94x | 1.29x |
+| `ContainsResource` (`ASK`) | 3.45x | 1.18x | 1.04x |
+| caller query, unselective scan | 2.24x | 0.97x | 0.94x |
+| caller query, selective | 4.23x | 1.47x | 2.33x |
+
+The in-memory ratios above 2x are on sub-millisecond absolutes where fixed cost dominates — the caller
+rows include parse, rewrite and re-parse, which the mapped reads skip entirely. The one number worth
+noting is the in-memory unselective scan: 1.50x before the set-semantics fix, 2.24x after, because the
+additions branch now carries a nested `NOT EXISTS`. Still inside the original 5x gate, and the price of
+a correct answer.
 
 **The cheap alternative was measured and rejected.** `COPY <baseline> TO <working>` works on all three
 stores — this contradicts the initial expectation that Virtuoso's `SPARQL { … }` update wrapper would
@@ -293,12 +313,35 @@ long-lived, write-heavy working copies; it is not this feature.
   read-only `IModel` base was considered and skipped: `ModelGroup` is load-bearing for existing
   consumers and this release favours not touching it.
 
+**Five defects were found in review after the first implementation**, three of them silent wrong
+answers, and they are recorded because each says something about where this design is fragile:
+
+1. **A union reached as an alternative of another union lost its disjunction** — emitted as a join.
+   Only the child-iteration path checked `IsUnion`, so `{{A} UNION {B}} UNION {C}` degraded. Since
+   `A UNION B UNION C` parses *left-nested*, this was the ordinary three-way case, not an edge one.
+2. **The overlay was a bag, not a set** — the branches overlapped, so a re-added triple produced two
+   solutions. Fixed by making them disjoint (above).
+3. **`GROUP BY` and `ORDER BY` expressions escaped the round-trip check**, so the dotNetRDF negation
+   defect reached them unnoticed. Both are now checked, direction included.
+4. **Blank-node patterns produced an unparseable rewrite** and were reported as a rewriter defect
+   rather than as the unsupported form they are.
+5. **`BIND` was relocated after all triple patterns**, which is invalid when its variable is used by
+   one of them — pattern reordering is now confined to contiguous runs of match patterns, since `BIND`
+   is order-sensitive and a triple pattern is not.
+
+The lesson is that a corpus of hand-written expectations only catches what someone thought to write
+down: the mislabelled corpus case ("blank node property list", which was a predicate-object list) is
+exactly why #4 survived it. `LayeredModelDifferentialTest` is the answer — with empty layers the view
+must answer exactly as the plain baseline model does, or refuse, so the baseline *is* the oracle and no
+expectations have to be authored. It catches #1, #3 and #5 directly, and was verified to fail when #1
+is reintroduced.
+
 **Explicitly out of scope for v1:** branching, merge, conflict detection, history, nested or stacked
 overlays, and views spanning more than one store. One baseline, one additions graph, one removals
 graph, one store.
 
-**Verified:** in-memory 542 passed / 3 pre-existing failures / 7 skipped; Virtuoso 175 passed / 4
-pre-existing failures / 1 skipped; GraphDB 182 passed / 4 pre-existing failures / 1 skipped. In each
+**Verified:** in-memory 589 passed / 3 pre-existing failures / 7 skipped; Virtuoso 221 passed / 4
+pre-existing failures / 1 skipped; GraphDB 228 passed / 4 pre-existing failures / 1 skipped. In each
 case the failure set is byte-identical to the same suite at the previous commit, and the delta is
 exactly the new tests (+27 in-memory, +16 per store). Fuseki is not covered: its suite is a
 hand-written non-generic copy and the backend is 4/86 on an upstream `FusekiConnector` bug (ADR-0036).

--- a/doc/adr/0042-staged-writes-and-accept.md
+++ b/doc/adr/0042-staged-writes-and-accept.md
@@ -1,0 +1,265 @@
+# 0042. Staged writes: the layered view as a working copy
+
+Date: 2026-08-20
+
+## Status
+Proposed
+
+Recorded because the reasoning below was expensive to arrive at and is easy to lose, not because the
+shape is settled. Several details are open — see *Deliberately unresolved* — and some of them touch
+parts of the system that have not been decided either.
+
+## Context
+
+[0041](0041-layered-read-views.md) delivered `ILayeredModel` as a **read-only** view:
+`(baseline − removals) ∪ additions`, with the two layer graphs exposed as ordinary `IModel`s so a
+caller stages a change by writing to them directly. That was the smallest correct surface, and it left
+three questions open that turn out to share a root:
+
+- **How does a change get applied back to the baseline?** There is no API for it; a caller has to write
+  the SPARQL themselves.
+- **Is this a branch?** It looks like one, and if it is, applying a change back is a merge — with all
+  that implies.
+- **Can the view be materialized** into a fourth graph so queries run natively, lifting the rewriter's
+  refusals (property paths, `GRAPH`, `CONSTRUCT`, inferencing)?
+
+The root they share: **while the layer graphs are written to directly, the view knows nothing about
+what changed.** That single fact is what makes staleness undetectable, what makes deleted values route
+incorrectly, and what makes the pre-change state unrecoverable. Each is addressed below, and each is
+addressed by the same decision.
+
+## Decision (proposed)
+
+### The view owns staging
+
+`Resource.Commit()` already routes through `_model.UpdateResource(this)`
+([Resource.cs:1196](../../Trinity/Resource.cs#L1196)). Implementing that on `LayeredModel` — to write
+the delta into the layer graphs rather than into a single model — makes `Commit()` **mean "stage"** for
+a resource read through a view. No new API, no caller change, which is the promise 0041 was built on.
+
+Two facts make this smaller than it looks:
+
+- The guard is `if (_model != null && IsReadOnly == false)`, and `LayeredModel.Attach()` currently sets
+  `IsReadOnly = true`. So today, modifying a resource read through a view and calling `Commit()` is a
+  **silent no-op** — the read-only-ness is enforced by silence rather than by an exception. Dropping
+  that flag is most of the work.
+- **This is not "a new write path in every store", which 0041 claimed.** That was wrong.
+  `SparqlSerializer.TrySerializeResourceDelta` is a store-independent static, already shared by all four
+  write paths (ADR-0039). Staging routes its two output lists to different graphs: one update builder in
+  `LayeredModel`, zero per-store work.
+
+**The trap: where deleted values go.** Routing every deleted value to the removals graph is wrong, and
+wrong silently:
+
+1. Stage `name = "new"` → additions gains `"new"`.
+2. Change your mind: `name = "newer"` → the delta reports `"new"` deleted, `"newer"` inserted.
+3. Put `"new"` in removals, and additions now holds `"new"` *and* `"newer"` while removals holds
+   `"new"` — and **additions win**, so both values are visible.
+
+The rule has to be conditional: for each deleted value, **remove it from additions if it is there**, and
+**add it to removals only if it is in the baseline** — possibly both, when a baseline triple had been
+re-added. This is the crux of staging, not a detail of it.
+
+### `Accept()` and `Discard()`, not `Commit()` and not `Merge()`
+
+Applying the change to the baseline is `ILayeredModel.Accept()`; abandoning it is `Discard()`.
+
+Not `Commit()`: once the view owns staging, `resource.Commit()` *means stage*, so a `view.Commit()` that
+means "push everything to the baseline" one level up is a genuine trap. `Accept`/`Discard` also matches
+the language 0041 already uses.
+
+Accept is O(changes) and server-side:
+
+```sparql
+DELETE { GRAPH <baseline> { ?s ?p ?o } } WHERE { GRAPH <removals>  { ?s ?p ?o } };
+INSERT { GRAPH <baseline> { ?s ?p ?o } } WHERE { GRAPH <additions> { ?s ?p ?o } };
+CLEAR GRAPH <additions>; CLEAR GRAPH <removals>
+```
+
+**Removals first, then additions** — so a triple in both survives, which is the same precedence the read
+path gives it. Worth stating as an invariant: additions win in both directions. Discard is the two
+`CLEAR`s alone.
+
+**Accept is not atomic on most backends.** Only Virtuoso has real transactions (ADR-0028); the others
+return `NoOpTransaction`, so a failure part-way leaves the baseline half-changed and the layers
+partly cleared.
+
+### It is a working copy, not a branch
+
+A **branch** can diverge, has its own history, and merging it needs *three-way* reconciliation against a
+recorded common ancestor. A **working copy** has one changeset against a live baseline, and applying it
+is a fast-forward when the baseline has not moved.
+
+So this stays `ILayeredModel`. A `BranchedModel` with `Merge()` would promise three-way reconciliation
+and conflict resolution that does not exist, and — the important part — **renaming would neither
+introduce conflicts nor avoid them.** The conflict potential is entirely a function of whether the
+baseline may move, which is orthogonal to what the type is called.
+
+Real branching stays a separate feature for a concrete reason rather than a naming one: three-way merge
+needs the ancestor, and it needs it *per branch*.
+
+### The ancestor is reconstructible, under an invariant
+
+The pre-change baseline `B₀` does not have to be stored. Given the materialized working copy:
+
+```
+effective = (B₀ − R) ∪ A        ⇒        B₀ = (effective ∖ A) ∪ R
+```
+
+Measured — exact for every disciplined changeset, and lossy in both directions without discipline:
+
+| staging | reconstruction |
+|---|---|
+| value change (remove old, add new) | exact |
+| pure addition | exact |
+| pure removal | exact |
+| re-add of a triple already in the baseline | **triple lost** from the reconstruction |
+| removal of a triple not in the baseline | **triple invented** in the reconstruction |
+
+The inversion holds exactly when `A ∩ B₀ = ∅` and `R ⊆ B₀` — never stage an addition that is already
+there, never stage a removal of something that is not. **Those are precisely what
+`TrySerializeResourceDelta` produces**, because a delta records only what changed; and precisely what a
+caller writing to the layer graphs directly can violate. A third independent reason for the view to own
+staging.
+
+Note what this needs: `B₀` is **not** recoverable from the current baseline plus the layers, because
+there is no way to tell which of the current baseline's triples were there originally and which a third
+party added. Reconstruction requires the **materialized** graph. So materialization is not merely a
+performance or coverage mode — it is the enabling condition for having an ancestor at all, and therefore
+for any future three-way merge.
+
+An alternative worth weighing: at creation the layers are empty, so the first materialization *is* `B₀`.
+Freezing that graph and maintaining the working copy separately costs a second full copy but depends on
+no invariant. Reconstruction is cheaper in storage and depends on discipline that is being enforced
+anyway.
+
+### Materialization as an opt-in mode
+
+Materializing `(baseline − removals) ∪ additions` into a fourth graph lets every query run natively
+against an ordinary model. The overlay macro **is** the materialization query — one `INSERT … WHERE`
+reusing what 0041 already emits, so there is no new machinery:
+
+```sparql
+INSERT { GRAPH <effective> { ?s ?p ?o } } WHERE { <the overlay> }
+```
+
+What it lifts, all of them 0041 refusals: **unbounded property paths** (verified — a chain whose hops
+straddle the layers resolves correctly, which no rewrite can achieve), `GRAPH` blocks, `CONSTRUCT`,
+`DESCRIBE`, `SERVICE`, **inferencing** (a store can reason over an ordinary graph), and arbitrary caller
+SPARQL with no whitelist, no `SparqlExpressionWriter` and no round-trip verification.
+
+What it costs: **18.1 s** to materialize 1,000,000 triples in-memory, plus a full duplicate of the
+baseline per view. Fine as opt-in, wrong as a default — which is why it is a mode and not a replacement.
+Materialization at that scale has **not** been measured on Virtuoso.
+
+What makes it practical is that it need not be recomputed. Staging changes exactly the layer contents,
+so the effective graph can be maintained **incrementally**: a staged addition inserts, a staged removal
+deletes unless the triple is still present via additions. That is **O(changes), not O(baseline)** — pay
+18 s once at creation, then next to nothing per stage. Incremental maintenance depends on the view
+owning staging, which is the fourth reason for it.
+
+**Staleness is silent, and that is the real objection.** Measured: stage a change, and the materialized
+graph still answers from before it while the rewriting view answers correctly, with no error either way.
+A snapshot that quietly answers from the past is exactly the failure class 0041 exists to prevent. It
+cannot be detected cheaply and reliably from outside — triple counts are unsound, since swapping one
+triple for another leaves the count unchanged, and there is no change notification (ADR-0035 removed
+`INotifyPropertyChanged`). So the mode is only defensible when the view observes every write, which is
+the same decision again.
+
+One limit survives regardless: the view can only know about **its own** layers. A third party writing to
+the baseline leaves the materialization stale and undetectably so. That is arguably outside the
+contract — the premise is that the baseline is untouched until accept — but it is an assumption, not a
+problem solved.
+
+### Conflicts do not fail. They merge, silently
+
+Because a changeset is a set of triples and `INSERT`/`DELETE` are idempotent, applying a stale change
+**never errors**. Measured, where a third party changed the same single-valued property:
+
+| scenario | baseline after accept |
+|---|---|
+| no third-party change | `["mine"]` — correct fast-forward |
+| third party set the same property to `"theirs"` | **`["mine", "theirs"]`** — two values for one property |
+
+For a multi-valued property, union is often what was wanted. For a functional one it is a silent schema
+violation.
+
+**A cheap precondition catches it.** Every triple staged for removal must still be present in the
+baseline; if one is not, the baseline moved on ground the change depends on:
+
+```sparql
+ASK { GRAPH <removals> { ?s ?p ?o } FILTER NOT EXISTS { GRAPH <baseline> { ?s ?p ?o } } }
+```
+
+Measured:
+
+| scenario | detected | outcome if applied anyway |
+|---|---|---|
+| competing change to one property | **yes** | `["mine","theirs"]` — the real conflict |
+| no third-party change | no | `["mine"]` — correct |
+| third party made the *same* removal | yes | `["mine"]` — benign, flagged anyway |
+| third party touched an unrelated triple | no | `["mine"]` — correct |
+
+It is O(removals) rather than O(baseline), **sound** — it catches every conflict of this shape — and
+deliberately **conservative**: it also flags the benign case where someone else already made the same
+removal. That is the right trade, and it is what a version control system does in the analogous
+situation, where the context a patch assumes no longer matches.
+
+`Accept()` therefore throws on divergence by default, with an explicit `force` to apply anyway. That
+puts the project's rule — never silently wrong — at the write boundary, where it has been missing.
+
+**What the precondition cannot see, and the honest boundary.** It does not catch *additions*-side
+conflicts, where a third party adds a competing value for a functional property the changeset also sets.
+Detecting that needs cardinality, and Trinity **already has it for mapped properties**: a
+`PropertyMapping<T>` with `IsList == false` is a functional-property declaration, and `GenericType` plus
+`XsdTypeMapper` gives the datatype. No new schema artifact is required for those.
+
+The gap is the **unmapped** surface, and it is not an oversight — ADR-0017 makes resources open, and
+`ListValues` returns unmapped predicates deliberately. For those, two values cannot be distinguished
+from a legitimate set. So the contract is: **conflict detection is exactly as good as mapping
+coverage.** Which argues that `Accept()` should not merely throw or not-throw but **report the split** —
+how many divergent triples fall on mapped functional properties, and how many on predicates it cannot
+judge. That turns an unquantified gamble into a measured risk, and it is the difference between a
+documented limitation and a trap.
+
+## Consequences
+
+- `resource.Commit()` works through a view with no caller change, which is what 0041 promised for reads
+  and did not deliver for writes.
+- Four separate problems — staleness detection, deleted-value routing, ancestor recoverability, and
+  incremental maintenance — are all solved by the same decision, which is the strongest argument that it
+  is the right one.
+- Two modes to document and test rather than one: rewriting (live, no extra storage, refuses exotic
+  forms) and materialized (full coverage, snapshot, extra storage). Refusal messages improve, because
+  they can point at the other mode instead of being a dead end.
+- Accept is non-atomic outside Virtuoso, which is a real exposure for a multi-triple changeset.
+- **A correction to 0041:** it stated that a writable view means "a new write path in every store". It
+  does not; the delta computation is store-independent and already shared. That overestimate made
+  read-only look more necessary than it was.
+
+## Deliberately unresolved
+
+Recorded so these are not mistaken for oversights:
+
+- **Validation of changesets.** Whether SHACL runs over a narrow graph derived from the changeset, what
+  its extent must be, and how much of a shapes graph the mapping can generate. Deliberately excluded
+  here; it touches parts of the system that are themselves unsettled.
+- **Reconstruct the ancestor or freeze it.** Both are described above; the choice depends on whether the
+  staging invariant is enforced strictly enough to be relied on.
+- **Atomicity of accept** on the non-transactional stores. Possibly a compensating log, possibly a
+  documented exposure.
+- **Additions-side conflict detection**, which needs the mapping-derived cardinality described above.
+- **Concurrent accepts** from two views over one baseline. That is branching, and needs a retained
+  per-view ancestor.
+- **Whether staging maintains the materialization incrementally or only marks it dirty**, and what a
+  stale materialized view does on read — refuse, or refresh silently.
+- **Whether `Accept()` should validate at all**, versus leaving that to the caller.
+
+## Related
+- [0041](0041-layered-read-views.md) — the read view this builds on, and the write-path claim it corrects
+- [0039](0039-resource-write-semantics.md) — the per-value delta that makes staging store-independent
+- [0029](0029-resource-commit-rollback-change-tracking.md) — `Commit`/`Rollback` semantics and no cascade
+- [0017](0017-resources-open-mapped-and-dynamic.md) — why unmapped predicates bound conflict detection
+- [0028](0028-store-level-transactions.md) — why accept is not atomic on most backends
+- [0014](0014-ontology-generator-modernization.md) — the generated-plus-committed artifact pattern any
+  generated shapes should follow

--- a/doc/adr/README.md
+++ b/doc/adr/README.md
@@ -86,6 +86,7 @@ mapped/dynamic duality, models & groups, discovery, stores, and querying.
 | # | Title | Status |
 |---|-------|--------|
 | [0015](0015-modernize-target-frameworks-and-ci.md) | Modernize target frameworks, build, and CI | Proposed |
+| [0042](0042-staged-writes-and-accept.md) | Staged writes: the layered view as a working copy (accept/discard, materialization, conflicts) | Proposed |
 
 ## Revival north star
 

--- a/doc/adr/README.md
+++ b/doc/adr/README.md
@@ -80,6 +80,7 @@ mapped/dynamic duality, models & groups, discovery, stores, and querying.
 | [0039](0039-resource-write-semantics.md) | Commits write a per-value delta, not the whole resource | Accepted |
 | [0014](0014-ontology-generator-modernization.md) | Reimplement ontology vocabulary generation as a `dotnet tool` | Accepted |
 | [0040](0040-numeric-conversion-on-read.md) | Numeric values are widened, never narrowed, when read into a mapped property | Accepted |
+| [0041](0041-layered-read-views.md) | Layered read views: baseline + additions − removals (working-copy semantics) | Accepted |
 
 ### Proposed (revival)
 | # | Title | Status |

--- a/tests/Trinity.Tests.GraphDB/GraphDBLayeredModelDifferentialTest.cs
+++ b/tests/Trinity.Tests.GraphDB/GraphDBLayeredModelDifferentialTest.cs
@@ -1,0 +1,38 @@
+// LICENSE:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// AUTHORS:
+//
+//  Moritz Eberl <moritz@semiodesk.com>
+//  Sebastian Faubel <sebastian@semiodesk.com>
+//
+// Copyright (c) Semiodesk GmbH 2026
+
+using NUnit.Framework;
+using Semiodesk.Trinity.Tests.Store;
+
+namespace Semiodesk.Trinity.Tests.GraphDB
+{
+    /// <summary>
+    /// Runs the layered-model differential sweep against GraphDB.
+    /// </summary>
+    [TestFixture]
+    public class GraphDBLayeredModelDifferentialTest : LayeredModelDifferentialTest<GraphDBTestSetup> { }
+}

--- a/tests/Trinity.Tests.GraphDB/GraphDBLayeredModelQueryCorpusTest.cs
+++ b/tests/Trinity.Tests.GraphDB/GraphDBLayeredModelQueryCorpusTest.cs
@@ -1,0 +1,38 @@
+// LICENSE:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// AUTHORS:
+//
+//  Moritz Eberl <moritz@semiodesk.com>
+//  Sebastian Faubel <sebastian@semiodesk.com>
+//
+// Copyright (c) Semiodesk GmbH 2026
+
+using NUnit.Framework;
+using Semiodesk.Trinity.Tests.Store;
+
+namespace Semiodesk.Trinity.Tests.GraphDB
+{
+    /// <summary>
+    /// Runs the layered-model SPARQL corpus against GraphDB.
+    /// </summary>
+    [TestFixture]
+    public class GraphDBLayeredModelQueryCorpusTest : LayeredModelQueryCorpusTest<GraphDBTestSetup> { }
+}

--- a/tests/Trinity.Tests.GraphDB/GraphDBLayeredModelTest.cs
+++ b/tests/Trinity.Tests.GraphDB/GraphDBLayeredModelTest.cs
@@ -1,0 +1,38 @@
+// LICENSE:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// AUTHORS:
+//
+//  Moritz Eberl <moritz@semiodesk.com>
+//  Sebastian Faubel <sebastian@semiodesk.com>
+//
+// Copyright (c) Semiodesk GmbH 2026
+
+using NUnit.Framework;
+using Semiodesk.Trinity.Tests.Store;
+
+namespace Semiodesk.Trinity.Tests.GraphDB
+{
+    /// <summary>
+    /// Runs the store-independent layered-model suite against GraphDB.
+    /// </summary>
+    [TestFixture]
+    public class GraphDBLayeredModelTest : LayeredModelTest<GraphDBTestSetup> { }
+}

--- a/tests/Trinity.Tests.Virtuoso/VirtuosoLayeredModelDifferentialTest.cs
+++ b/tests/Trinity.Tests.Virtuoso/VirtuosoLayeredModelDifferentialTest.cs
@@ -1,0 +1,38 @@
+// LICENSE:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// AUTHORS:
+//
+//  Moritz Eberl <moritz@semiodesk.com>
+//  Sebastian Faubel <sebastian@semiodesk.com>
+//
+// Copyright (c) Semiodesk GmbH 2026
+
+using NUnit.Framework;
+using Semiodesk.Trinity.Tests.Store;
+
+namespace Semiodesk.Trinity.Tests.Virtuoso
+{
+    /// <summary>
+    /// Runs the layered-model differential sweep against Virtuoso.
+    /// </summary>
+    [TestFixture]
+    public class VirtuosoLayeredModelDifferentialTest : LayeredModelDifferentialTest<VirtuosoTestSetup> { }
+}

--- a/tests/Trinity.Tests.Virtuoso/VirtuosoLayeredModelQueryCorpusTest.cs
+++ b/tests/Trinity.Tests.Virtuoso/VirtuosoLayeredModelQueryCorpusTest.cs
@@ -1,0 +1,38 @@
+// LICENSE:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// AUTHORS:
+//
+//  Moritz Eberl <moritz@semiodesk.com>
+//  Sebastian Faubel <sebastian@semiodesk.com>
+//
+// Copyright (c) Semiodesk GmbH 2026
+
+using NUnit.Framework;
+using Semiodesk.Trinity.Tests.Store;
+
+namespace Semiodesk.Trinity.Tests.Virtuoso
+{
+    /// <summary>
+    /// Runs the layered-model SPARQL corpus against Virtuoso.
+    /// </summary>
+    [TestFixture]
+    public class VirtuosoLayeredModelQueryCorpusTest : LayeredModelQueryCorpusTest<VirtuosoTestSetup> { }
+}

--- a/tests/Trinity.Tests.Virtuoso/VirtuosoLayeredModelTest.cs
+++ b/tests/Trinity.Tests.Virtuoso/VirtuosoLayeredModelTest.cs
@@ -1,0 +1,38 @@
+// LICENSE:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// AUTHORS:
+//
+//  Moritz Eberl <moritz@semiodesk.com>
+//  Sebastian Faubel <sebastian@semiodesk.com>
+//
+// Copyright (c) Semiodesk GmbH 2026
+
+using NUnit.Framework;
+using Semiodesk.Trinity.Tests.Store;
+
+namespace Semiodesk.Trinity.Tests.Virtuoso
+{
+    /// <summary>
+    /// Runs the store-independent layered-model suite against Virtuoso.
+    /// </summary>
+    [TestFixture]
+    public class VirtuosoLayeredModelTest : LayeredModelTest<VirtuosoTestSetup> { }
+}


### PR DESCRIPTION
## What

A `ModelGroup` can only union: its dataset clause is one `FROM` per member, and SPARQL has no inverse of that. This adds `ILayeredModel` — a read view over a **baseline** graph plus a pending change held as an **additions** and a **removals** graph — so everything reading through it sees `(baseline − removals) ∪ additions` while the baseline itself stays untouched until the change is accepted or discarded. A git working tree, expressed in RDF.

Mapped-object reads are the point: `GetResource`, `GetResource<T>`, `GetResources<T>` and `ContainsResource` honour the overlay, so code written against `IModel` needs no change.

```csharp
var view = store.CreateLayeredModel(baseline, additions, removals);

// stage a change by writing to the layer models, which are ordinary IModels
// then read through the view as if it had been applied
var person = view.GetResource<Person>(uri);          // sees the staged value
view.AsQueryable<Person>().Where(p => p.Name == "…"); // and so does selection
```

A triple in **both** additions and removals is **visible** — additions win. That is what makes an ordinary value edit (remove the old, add the new) behave the way callers expect.

## Design

**Not an `IModelGroup`.** A group is an `ISet<IModel>` of interchangeable members; these three graphs have distinct roles, so set membership means nothing for them. Keeping the types apart also stops the existing union-only paths — the `is IModelGroup` branches in the `SparqlQuery` model setter and `GenerateDatasetClause`, and GraphDB's inference path — from mistaking a view for a plain group. **The `IModelGroup` contract is untouched and no existing consumer changes behaviour.**

**Created via a `StoreExtensions` method, not a new `IStore` member**, so no backend has to change, and the empty-group bug that three stores carry in `CreateModelGroup(params IModel[])` is not reproduced. The constructor is `internal`: all three graphs must live in one store, because the overlay is a single query over a single dataset. Composing one across stores was measured and **fails silently in both directions** — returning triples staged for removal, or dropping the baseline entirely — so routing construction through the factory makes that unrepresentable rather than merely discouraged.

**Read-only.** Stage a change by writing to `Additions`/`Removals`. Routing writes automatically would mean splitting the `WITH <g> DELETE {…} INSERT {…}` delta from `StoreBase.TryBuildDeltaUpdate` so its DELETE half becomes an INSERT into the removals graph — a new write path in every store. Deferred.

**`IModelGroup.DefaultModel` turns out to be dead** — declared, auto-implemented, never read or assigned anywhere. Recorded in ADR-0019; removing it is a breaking public-interface change and left for its own PR.

## Three emission rules that are requirements, not optimisations

Subtraction has to live in the graph pattern, so `LayeredModelSparql` is the single source of truth. Each rule below was measured, and getting one wrong is either a silent wrong answer or four orders of magnitude:

1. **`MINUS` where the pattern binds a variable, `FILTER NOT EXISTS` where it is fully ground.** `MINUS` is far faster — an anti-join instead of a per-row probe, 18× → 1.5× on an unselective scan — but it removes nothing when the two sides share no variables, and a ground pattern has none. There it **silently fails to subtract**. Verified: the in-memory store and GraphDB are spec-correct here; Virtuoso is the deviation.
2. **Bind a known subject with `VALUES` before the overlay**, never as a trailing `FILTER`. Neither the in-memory engine nor GraphDB pushes a filter into a `UNION` containing an anti-join — 15× and 38× against ~1.0×.
3. **Selective patterns before the wildcard `?s ?p ?o`.** An engine that cannot reorder joins across the overlay's `UNION` evaluates them as written, so a leading wildcard materialises the whole effective graph first: **61,000×** in-memory. `BuildResourceQuery` previously emitted the wildcard first — hence the change there. Pattern order inside a BGP is semantically irrelevant, so plain models are unaffected.

## Query coverage

**LINQ is honoured natively** because Trinity owns its AST: only `TriplePattern` resolves against data, so wrapping one `case` arm of `SparqlQueryWriter` is exhaustive by construction, and the existing `default: throw` keeps a future node type from leaking.

**Caller SPARQL is rewritten** by `OverlayQueryRewriter`, working on the parse tree rather than the text — the abbreviations that defeat a token-level rewrite (`;`, `,`, `[ ]`) are already expanded by the time the parser is done. It is a whitelist; anything unrecognised throws with a reason.

| Refused | Why |
|---|---|
| property paths | walks intermediate nodes that must themselves resolve against the effective graph; `+`/`*` have no fixed expansion |
| `GRAPH` blocks | a view is built from three graphs; naming one reads past the overlay, and `GRAPH ?g` exposes the removals graph as data |
| `SERVICE` | the remote endpoint knows nothing of the overlay |
| `CONSTRUCT` / `DESCRIBE` | a template describes triples to build, not match; `DESCRIBE` has no pattern to rewrite |
| `FILTER EXISTS` / `NOT EXISTS` | an `ExistsFunction` inside the filter expression, whose nested pattern would read the baseline directly |
| a caller `FROM` / `FROM NAMED` | the view defines the dataset |
| `inferenceEnabled: true` | every store's inference path defeats the overlay, and entailment over a subtracted graph is undefined |

Refusing matters because running such a query unchanged is wrong **two different ways**, neither of which announces itself: a default-graph pattern returns *nothing* (the view names its graphs with `FROM NAMED`, leaving the default graph empty), while a pattern naming a graph returns triples staged for removal.

## An upstream serialisation defect, contained

dotNetRDF drops the parentheses around a negation's operand: `!(?r < 3)` → `!?r < 3`, i.e. `(!?r) < 3` — **and it still parses**. `SparqlFormatter` has the same defect. Parsing is fine; only writing out is wrong.

`SparqlExpressionWriter` therefore serialises expressions itself, parenthesising every operator application so correctness needs no precedence table. **22/22 faithful against dotNetRDF's 17/22.** `HAVING` and projected expressions come from dotNetRDF's serialisation of the query head and cannot be repaired here, only detected — so a negation in either is refused with a suggested rephrasing.

**Every rewrite is re-parsed and compared structurally** against the original — query form, `LIMIT`, `OFFSET`, projected variables, `HAVING`, projections, and every filter and `BIND` expression. That check found two defects during development that no test of the output would have: clauses held in `UnplacedFilters`/`UnplacedAssignments` were being **dropped from the rewrite entirely**, and one filter reachable through both `Filter` and `UnplacedFilters` was double-counted.

## Performance

Layered ÷ plain at **1,000,000** baseline triples, ~100 staged additions and ~100 staged removals:

| Read shape | in-memory | Virtuoso | GraphDB |
|---|---|---|---|
| `GetResource` (subject-bound) | 1.55× | 1.06× | 0.86× |
| LINQ `Where` (selective) | 3.00× | 1.03× | 1.55× |
| `GetResources<T>()` (unselective scan) | 1.50× | 1.05× | 1.14× |

**The cheaper-sounding alternative was measured and rejected.** Server-side `COPY` works on all three stores — correcting an expectation that Virtuoso's `SPARQL { … }` update wrapper would reject it — but costs 3.9–6.0 s and a full duplicate of the baseline *per working copy* at 1M triples, and moves the accept-time cost to an O(baseline) diff instead of reading an O(changes) delta.

**Accepted cost, documented as a follow-up:** a caller query is parsed, walked, re-emitted and re-parsed on *every* execution, because the strict parser rejects Trinity's `@parameter` syntax so the rewrite runs after binding. ADR-0041 records the fix for when it matters — substitute each `@parameter` with a placeholder IRI before parsing, rewrite once, cache, map back — which makes it a per-query-shape cost, needs no parser change, and keeps the verification applicable. Affects caller SPARQL only; mapped reads and LINQ never touch the rewriter.

## Tests

Run against **every backend with a fixture**, because the union half of the overlay is exactly where backends differ. `LayeredModelQueryCorpusTest` is a data-driven corpus of caller SPARQL with expected results plus the forms that must be refused; every case is built so the answer *differs* depending on whether the overlay was applied, so a query ignoring subtraction fails rather than coincidentally agreeing.

| Suite | develop | this branch | Δ | failure set |
|---|---|---|---|---|
| in-memory | 410 P / 3 F / 7 S | **542 P** / 3 F / 7 S | +132 | identical |
| Virtuoso | 103 P / 4 F / 1 S | **175 P** / 4 F / 1 S | +72 | identical |
| GraphDB | 110 P / 4 F / 1 S | **182 P** / 4 F / 1 S | +72 | identical |
| Fuseki | 4 P / 82 F | 4 P / 82 F | +0 | identical |
| Generator / Vocabulary | 23 P / 29 P | 23 P / 29 P | — | clean |

**No new failures on any backend.** I measured each `develop` baseline in a clean worktree under the same conditions and diffed the failure *names*, not just the counts — byte-identical throughout.

⚠️ **Pre-existing failures a reviewer will see, all reproducing on `develop`:**
- **in-memory (3)** — `Equal`, `ResourceConstructorTest`, `EqualsTest`. Appear to be an artefact of running under `DOTNET_ROLL_FORWARD=LatestMajor` on .NET 10 where no net8.0 runtime is installed.
- **Virtuoso / GraphDB (4 each)** — the inferencing tests, consistent with this design refusing inferencing.
- **Fuseki (82)** — the documented 4/86, HTTP 404/405 from the upstream `FusekiConnector` bug (ADR-0036). This branch adds no Fuseki tests; the 79 distinct failure names match `develop` exactly, which was the open question given the `SparqlSerializer` and LINQ translator changes.

Store suites are Docker/Testcontainers and excluded from the default CI job (ADR-0036), so CI will only show the in-memory run. All three were provisioned fresh locally and are reported above.

## Non-goals

Branching, merge, conflict detection, history, nested or stacked overlays, and views spanning more than one store. One baseline, one additions graph, one removals graph, one store.

## Review guide

Three commits, each of which builds (verified in a throwaway worktree):

1. **`1e6a5c9`** product code — `Trinity.csproj` builds alone
2. **`bab3029`** tests — solution builds, suite green
3. **`2a3c80b`** docs — ADR-0041, the ADR-0019 note, index, `CLAUDE.md`

`LayeredModel` and `OverlayQueryRewriter` reference each other, so the product code could not be sliced finer without a non-building intermediate.

**Start with `doc/adr/0041-layered-read-views.md`** — it carries the reasoning, the measured numbers, and the reasons behind each refusal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
