### PR TITLE
Staged writes: the layered view as a working copy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ is netstandard2.0 / net8.0 and builds cross-platform.
 
 ```bash
 dotnet build Semiodesk.Trinity.sln -c Release          # whole solution, SDK-only
-dotnet test Trinity.Tests/Trinity.Tests.csproj         # 589 passed, 7 skipped (quarantined)
+dotnet test Trinity.Tests/Trinity.Tests.csproj         # 602 passed, 7 skipped (quarantined)
 dotnet test tests/Trinity.Generator.Tests/Trinity.Generator.Tests.csproj   # 23 passed
 dotnet test tests/Trinity.Vocabulary.Tests/Trinity.Vocabulary.Tests.csproj # 29 passed
 dotnet pack Trinity/Trinity.csproj -c Release          # -> Semiodesk.Trinity.2.0.0.nupkg
@@ -69,7 +69,7 @@ dotnet pack Trinity/Trinity.csproj -c Release          # -> Semiodesk.Trinity.2.
 - Store integration tests (`tests/Trinity.Tests.*`) **self-provision** their server in Docker via
   Testcontainers on a random host port (ADR-0036): run `dotnet test tests/Trinity.Tests.{Virtuoso,GraphDB,Fuseki}`
   with a Docker daemon running. Excluded from the default CI job (Docker + large images). Current:
-  Virtuoso 221/226 and GraphDB 228/233 pass; Fuseki is 4/86 — a pre-existing dotNetRDF `FusekiConnector`
+  Virtuoso 234/239 and GraphDB 241/246 pass; Fuseki is 4/86 — a pre-existing dotNetRDF `FusekiConnector`
   query-endpoint bug (POSTs `/ds/query`, which the server 404s), unrelated to the container wiring.
   Virtuoso's `Int16Test`/`Uint16Test`/`UintTest` are now `Assert.Inconclusive` in `VirtuosoResourceTest`,
   alongside the pre-existing `Int64Test`/`Uint64Test` overrides for the same phenomenon: Virtuoso widens
@@ -188,6 +188,15 @@ Invariants that surprise newcomers:
   **All three graphs must be in the same store** — the overlay is one query over one dataset, so a cross-store view
   is refused at construction (it used to fail silently in both directions); create views only via
   `store.CreateLayeredModel`, never by constructing `LayeredModel` directly.
+- **A layered view is a working copy you stage into** (0042): `Commit()` on a resource read through one
+  **stages** into the additions/removals graphs rather than writing — it was a silent no-op before — and
+  `Accept()`/`Discard()` apply or abandon. Accept applies removals before additions (additions win, as on
+  read) and **refuses** when a triple staged for removal is no longer in the baseline, because a stale
+  changeset never fails on its own: it merges, leaving two values for a single-valued property that a
+  mapped read then hides. `Accept(force: true)` overrides. Deleted values route conditionally — un-stage
+  from additions, add to removals only if the baseline holds it — which is what keeps the ancestor
+  reconstructible. Never write `WHERE { FILTER … }` with no pattern: **Virtuoso ignores a filter-only
+  WHERE** and applies the operation unconditionally.
 - **Discovery is global static state** (0020): consumers must `MappingDiscovery.RegisterAssembly`
   / `OntologyDiscovery.AddAssembly` at startup or mapping and SPARQL prefixes silently miss.
 - **No configuration subsystem** (0011, 2.0): the `ontologies.config`/`app.config` loading,

--- a/Trinity.Tests/LayeredModelSparqlTest.cs
+++ b/Trinity.Tests/LayeredModelSparqlTest.cs
@@ -284,15 +284,24 @@ namespace Semiodesk.Trinity.Tests
                 "GetResource",
                 "GetResources",
                 "AsQueryable",
-                // Reads that deliberately refuse a caller query but are not read-only refusals.
+                // Reads that rewrite a caller query, refusing forms they cannot handle.
                 "ExecuteQuery", "GetBindings",
+                // Writes, which stage into the additions and removals graphs rather than write.
+                "AddResource", "CreateResource", "DeleteResource", "DeleteResources",
+                "UpdateResource", "UpdateResources",
+                // Delegated to the store so Accept can run in a real transaction where there is one.
+                "BeginTransaction",
             };
 
             var refused = new HashSet<string>
             {
-                "AddResource", "CreateResource", "DeleteResource", "DeleteResources",
-                "UpdateResource", "UpdateResources", "ExecuteUpdate", "Clear",
-                "Read", "Write", "BeginTransaction",
+                // Cannot be routed into the layers: there is no way to tell which of a caller update's
+                // effects should become an addition and which a removal.
+                "ExecuteUpdate",
+                // Ambiguous on a view; Discard() is the meaningful operation.
+                "Clear",
+                // A different operation from reading into or writing out a model.
+                "Read", "Write",
             };
 
             var unclassified = new List<string>();
@@ -318,17 +327,10 @@ namespace Semiodesk.Trinity.Tests
 
             var alwaysThrows = new List<TestDelegate>
             {
-                () => view.AddResource(new Resource(new Uri("urn:x"))),
-                () => view.CreateResource(new Uri("urn:x")),
-                () => view.DeleteResource(new Uri("urn:x")),
-                () => view.DeleteResources(new[] { new Uri("urn:x") }),
-                () => view.UpdateResource(new Resource(new Uri("urn:x"))),
-                () => view.UpdateResources(new[] { new Resource(new Uri("urn:x")) }),
                 () => view.ExecuteUpdate(new SparqlUpdate("CLEAR GRAPH <urn:x>")),
                 () => view.Clear(),
                 () => view.Read(new Uri("urn:x"), RdfSerializationFormat.Turtle, false),
                 () => view.Write(new System.IO.MemoryStream(), RdfSerializationFormat.Turtle),
-                () => view.BeginTransaction(System.Data.IsolationLevel.ReadCommitted),
             };
 
             foreach (TestDelegate call in alwaysThrows)

--- a/Trinity.Tests/Store/DotNetRDF/DotNetRDFLayeredModelStagingTest.cs
+++ b/Trinity.Tests/Store/DotNetRDF/DotNetRDFLayeredModelStagingTest.cs
@@ -1,0 +1,38 @@
+// LICENSE:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// AUTHORS:
+//
+//  Moritz Eberl <moritz@semiodesk.com>
+//  Sebastian Faubel <sebastian@semiodesk.com>
+//
+// Copyright (c) Semiodesk GmbH 2026
+
+using NUnit.Framework;
+using Semiodesk.Trinity.Tests.Store;
+
+namespace Semiodesk.Trinity.Tests.DotNetRDF
+{
+    /// <summary>
+    /// Runs the staged-writes suite against the dotNetRDF in-memory store.
+    /// </summary>
+    [TestFixture]
+    public class DotNetRDFLayeredModelStagingTest : LayeredModelStagingTest<DotNetRDFTestSetup> { }
+}

--- a/Trinity.Tests/Store/LayeredModelStagingTest.cs
+++ b/Trinity.Tests/Store/LayeredModelStagingTest.cs
@@ -1,0 +1,405 @@
+// LICENSE:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// AUTHORS:
+//
+//  Moritz Eberl <moritz@semiodesk.com>
+//  Sebastian Faubel <sebastian@semiodesk.com>
+//
+// Copyright (c) Semiodesk GmbH 2026
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+using Semiodesk.Trinity.Ontologies;
+
+namespace Semiodesk.Trinity.Tests.Store
+{
+    /// <summary>
+    /// Staged writes through a layered view: <c>Commit()</c> stages, <c>Accept()</c> applies,
+    /// <c>Discard()</c> abandons.
+    /// </summary>
+    /// <remarks>
+    /// Runs on every backend with a fixture, because staging and accept are both multi-operation
+    /// SPARQL updates and that is exactly where backends have differed throughout this work.
+    /// </remarks>
+    [TestFixture]
+    public abstract class LayeredModelStagingTest<T> : StoreTest<T> where T : IStoreTestSetup
+    {
+        #region Members
+
+        protected IModel Baseline;
+        protected IModel Additions;
+        protected IModel Removals;
+        protected ILayeredModel View;
+
+        protected UriRef R1;
+        protected UriRef R2;
+
+        #endregion
+
+        #region Setup
+
+        [SetUp]
+        public override void SetUp()
+        {
+            base.SetUp();
+
+            Baseline = Store.GetModel(BaseUri.GetUriRef("stage-baseline"));
+            Additions = Store.GetModel(BaseUri.GetUriRef("stage-additions"));
+            Removals = Store.GetModel(BaseUri.GetUriRef("stage-removals"));
+
+            foreach (IModel model in new[] { Baseline, Additions, Removals })
+            {
+                if (!model.IsEmpty) model.Clear();
+            }
+
+            View = Store.CreateLayeredModel(Baseline.Uri, Additions.Uri, Removals.Uri);
+
+            R1 = BaseUri.GetUriRef("sr1");
+            R2 = BaseUri.GetUriRef("sr2");
+        }
+
+        [TearDown]
+        public void TearDownStaging()
+        {
+            Baseline.Clear();
+            Additions.Clear();
+            Removals.Clear();
+        }
+
+        private MappingTestClass GivenBaseline(UriRef uri, string value)
+        {
+            var resource = Baseline.CreateResource<MappingTestClass>(uri);
+            resource.uniqueStringTest = value;
+            resource.Commit();
+
+            return resource;
+        }
+
+        private int CountIn(IModel model, Uri subject)
+        {
+            var query = new SparqlQuery($"SELECT ?p ?o FROM <{model.Uri}> WHERE {{ <{subject}> ?p ?o }}",
+                declarePrefixes: false);
+
+            return model.GetBindings(query).Count();
+        }
+
+        #endregion
+
+        #region Staging
+
+        /// <summary>
+        /// A resource read through a view is writable, and committing it stages rather than writes.
+        /// </summary>
+        /// <remarks>
+        /// This used to be a silent no-op: <c>Attach</c> marked the resource read-only and
+        /// <c>Resource.Commit()</c> is guarded by that flag, so a caller's change was discarded without
+        /// a word.
+        /// </remarks>
+        [Test]
+        public virtual void CommitThroughTheViewStagesRatherThanWrites()
+        {
+            GivenBaseline(R1, "original");
+
+            var seen = View.GetResource<MappingTestClass>(R1);
+            seen.uniqueStringTest = "staged";
+            seen.Commit();
+
+            Assert.AreEqual("staged", View.GetResource<MappingTestClass>(R1).uniqueStringTest,
+                "the view must show the staged value");
+            Assert.AreEqual("original", Baseline.GetResource<MappingTestClass>(R1).uniqueStringTest,
+                "the baseline must be untouched");
+        }
+
+        /// <summary>
+        /// Staging the same property twice must not leave both values visible.
+        /// </summary>
+        /// <remarks>
+        /// The routing crux. Sending every deleted value to the removals graph looks obviously right and
+        /// is silently wrong: the first staged value would sit in additions, the second too, and the
+        /// first would also be in removals — where additions win, so both stay visible.
+        /// </remarks>
+        [Test]
+        public virtual void StagingTheSamePropertyTwiceLeavesOneValue()
+        {
+            GivenBaseline(R1, "original");
+
+            var first = View.GetResource<MappingTestClass>(R1);
+            first.uniqueStringTest = "staged once";
+            first.Commit();
+
+            var second = View.GetResource<MappingTestClass>(R1);
+            second.uniqueStringTest = "staged twice";
+            second.Commit();
+
+            var values = View.GetResource(R1).ListValues(to.uniqueStringTest).Select(v => v.ToString()).ToList();
+
+            Assert.AreEqual(new[] { "staged twice" }, values,
+                "only the most recently staged value may be visible");
+        }
+
+        /// <summary>
+        /// Re-staging the baseline's own value un-stages the removal rather than piling up graphs.
+        /// </summary>
+        [Test]
+        public virtual void RestoringTheBaselineValueEmptiesBothLayers()
+        {
+            GivenBaseline(R1, "original");
+
+            var changed = View.GetResource<MappingTestClass>(R1);
+            changed.uniqueStringTest = "temporary";
+            changed.Commit();
+
+            var restored = View.GetResource<MappingTestClass>(R1);
+            restored.uniqueStringTest = "original";
+            restored.Commit();
+
+            Assert.AreEqual("original", View.GetResource<MappingTestClass>(R1).uniqueStringTest);
+            Assert.AreEqual(0, CountIn(Additions, R1), "additions must not keep a value the baseline already has");
+            Assert.AreEqual(0, CountIn(Removals, R1), "the staged removal must have been un-staged");
+        }
+
+        /// <summary>
+        /// The invariants that keep the pre-change baseline reconstructible (ADR-0042).
+        /// </summary>
+        [Test]
+        public virtual void StagingMaintainsTheAncestorInvariants()
+        {
+            GivenBaseline(R1, "original");
+            GivenBaseline(R2, "second");
+
+            var a = View.GetResource<MappingTestClass>(R1);
+            a.uniqueStringTest = "changed";
+            a.Commit();
+
+            var b = View.CreateResource<MappingTestClass>(BaseUri.GetUriRef("sr3"));
+            b.uniqueStringTest = "brand new";
+            b.Commit();
+
+            View.DeleteResource(R2);
+
+            Assert.IsFalse(Ask($"ASK FROM NAMED <{Additions.Uri}> FROM NAMED <{Baseline.Uri}> " +
+                    $"WHERE {{ GRAPH <{Additions.Uri}> {{ ?s ?p ?o }} GRAPH <{Baseline.Uri}> {{ ?s ?p ?o }} }}"),
+                "additions must share no triple with the baseline (A n B0 = {})");
+
+            Assert.IsFalse(Ask($"ASK FROM NAMED <{Removals.Uri}> FROM NAMED <{Baseline.Uri}> " +
+                    $"WHERE {{ GRAPH <{Removals.Uri}> {{ ?s ?p ?o }} FILTER NOT EXISTS {{ GRAPH <{Baseline.Uri}> {{ ?s ?p ?o }} }} }}"),
+                "every staged removal must be present in the baseline (R subset of B0)");
+        }
+
+        private bool Ask(string sparql) =>
+            Baseline.ExecuteQuery(new SparqlQuery(sparql, declarePrefixes: false)).GetAnwser();
+
+        [Test]
+        public virtual void CreateResourceThroughTheViewStagesAnAddition()
+        {
+            var created = View.CreateResource<MappingTestClass>(R1);
+            created.uniqueStringTest = "new";
+            created.Commit();
+
+            Assert.AreEqual("new", View.GetResource<MappingTestClass>(R1).uniqueStringTest);
+            Assert.IsFalse(Baseline.ContainsResource(R1), "the baseline must not have gained it");
+        }
+
+        [Test]
+        public virtual void DeleteResourceThroughTheViewStagesRemovals()
+        {
+            GivenBaseline(R1, "original");
+
+            View.DeleteResource(R1);
+
+            Assert.IsFalse(View.ContainsResource(R1), "the resource must be invisible through the view");
+            Assert.IsTrue(Baseline.ContainsResource(R1), "but still present in the baseline");
+        }
+
+        #endregion
+
+        #region Accept and discard
+
+        [Test]
+        public virtual void AcceptAppliesTheStagedChangeAndEmptiesTheLayers()
+        {
+            GivenBaseline(R1, "original");
+
+            var changed = View.GetResource<MappingTestClass>(R1);
+            changed.uniqueStringTest = "accepted";
+            changed.Commit();
+
+            View.Accept();
+
+            Assert.AreEqual("accepted", Baseline.GetResource<MappingTestClass>(R1).uniqueStringTest,
+                "the baseline must now hold what the view showed");
+            Assert.IsTrue(Additions.IsEmpty, "additions must be empty after accept");
+            Assert.IsTrue(Removals.IsEmpty, "removals must be empty after accept");
+        }
+
+        [Test]
+        public virtual void DiscardLeavesTheBaselineUntouched()
+        {
+            GivenBaseline(R1, "original");
+
+            var changed = View.GetResource<MappingTestClass>(R1);
+            changed.uniqueStringTest = "abandoned";
+            changed.Commit();
+
+            View.Discard();
+
+            Assert.AreEqual("original", Baseline.GetResource<MappingTestClass>(R1).uniqueStringTest);
+            Assert.AreEqual("original", View.GetResource<MappingTestClass>(R1).uniqueStringTest,
+                "and the view reads the baseline again");
+            Assert.IsTrue(Additions.IsEmpty);
+            Assert.IsTrue(Removals.IsEmpty);
+        }
+
+        /// <summary>
+        /// Accept applies removals before additions, so a triple staged in both survives.
+        /// </summary>
+        [Test]
+        public virtual void AcceptGivesAdditionsPrecedenceJustAsReadsDo()
+        {
+            GivenBaseline(R1, "original");
+
+            // Stage the baseline triple for removal and, separately, right back as an addition.
+            Removals.ExecuteUpdate(new SparqlUpdate(
+                "INSERT { GRAPH @removals { ?s ?p ?o } } WHERE { GRAPH @baseline { ?s ?p ?o } }")
+                .Bind("@removals", Removals).Bind("@baseline", Baseline));
+            Additions.ExecuteUpdate(new SparqlUpdate(
+                "INSERT { GRAPH @additions { ?s ?p ?o } } WHERE { GRAPH @removals { ?s ?p ?o } }")
+                .Bind("@additions", Additions).Bind("@removals", Removals));
+
+            Assert.AreEqual("original", View.GetResource<MappingTestClass>(R1).uniqueStringTest,
+                "precondition: additions win on read");
+
+            View.Accept(force: true);
+
+            Assert.AreEqual("original", Baseline.GetResource<MappingTestClass>(R1).uniqueStringTest,
+                "and additions win on accept too");
+        }
+
+        #endregion
+
+        #region Divergence
+
+        [Test]
+        public virtual void AcceptRefusesWhenTheBaselineMovedUnderTheChange()
+        {
+            GivenBaseline(R1, "original");
+
+            var changed = View.GetResource<MappingTestClass>(R1);
+            changed.uniqueStringTest = "mine";
+            changed.Commit();
+
+            Assert.IsFalse(View.HasDiverged(), "nothing has moved yet");
+
+            // A third party changes the same property.
+            var theirs = Baseline.GetResource<MappingTestClass>(R1);
+            theirs.uniqueStringTest = "theirs";
+            theirs.Commit();
+
+            Assert.IsTrue(View.HasDiverged(), "the triple staged for removal is no longer in the baseline");
+
+            var ex = Assert.Throws<InvalidOperationException>(() => View.Accept());
+            Assert.That(ex.Message, Does.Contain("staged"));
+        }
+
+        /// <summary>
+        /// Forcing a stale change merges instead of failing — and the damage is invisible through the
+        /// mapped API.
+        /// </summary>
+        /// <remarks>
+        /// This is the whole reason <see cref="ILayeredModel.Accept"/> refuses by default. A changeset
+        /// is a set of triples and INSERT/DELETE are idempotent, so applying one computed against a
+        /// baseline that has moved cannot fail; it silently merges. Here the baseline ends up holding
+        /// <b>two</b> values for a single-valued property.
+        /// <para>
+        /// Worse, and the reason this test asserts against the store rather than through a resource:
+        /// <c>uniqueStringTest</c> is a <c>PropertyMapping&lt;string&gt;</c>, so a mapped read collapses
+        /// the two stored values to one. The schema violation is real in the data and invisible through
+        /// the API a caller would normally use to look for it.
+        /// </para>
+        /// </remarks>
+        [Test]
+        public virtual void ForcedAcceptMergesAndTheDamageIsInvisibleToMappedReads()
+        {
+            GivenBaseline(R1, "original");
+
+            var changed = View.GetResource<MappingTestClass>(R1);
+            changed.uniqueStringTest = "mine";
+            changed.Commit();
+
+            var theirs = Baseline.GetResource<MappingTestClass>(R1);
+            theirs.uniqueStringTest = "theirs";
+            theirs.Commit();
+
+            View.Accept(force: true);
+
+            var stored = Baseline.GetBindings(new SparqlQuery(
+                $"SELECT ?o FROM <{Baseline.Uri}> WHERE {{ <{R1}> <{to.uniqueStringTest.Uri}> ?o }}",
+                declarePrefixes: false))
+                .Select(b => b["o"].ToString())
+                .OrderBy(v => v)
+                .ToList();
+
+            Assert.AreEqual(new[] { "mine", "theirs" }, stored,
+                "forcing a stale change merges rather than failing, leaving two values for a " +
+                "single-valued property");
+
+            Assert.AreEqual(1,
+                Baseline.GetResource<MappingTestClass>(R1).uniqueStringTest == null ? 0 : 1,
+                "and a mapped read shows only one of them, so the violation does not surface where a " +
+                "caller would look for it");
+        }
+
+        [Test]
+        public virtual void AnUnrelatedBaselineChangeIsNotDivergence()
+        {
+            GivenBaseline(R1, "original");
+            GivenBaseline(R2, "second");
+
+            var changed = View.GetResource<MappingTestClass>(R1);
+            changed.uniqueStringTest = "mine";
+            changed.Commit();
+
+            var other = Baseline.GetResource<MappingTestClass>(R2);
+            other.uniqueStringTest = "also changed";
+            other.Commit();
+
+            Assert.IsFalse(View.HasDiverged(), "a change elsewhere in the baseline is not a conflict");
+            Assert.DoesNotThrow(() => View.Accept());
+        }
+
+        #endregion
+
+        #region Still refused
+
+        [Test]
+        public virtual void CallerUpdatesAndSerializationStayRefused()
+        {
+            Assert.Throws<NotSupportedException>(
+                () => View.ExecuteUpdate(new SparqlUpdate($"CLEAR GRAPH <{Additions.Uri}>")));
+            Assert.Throws<NotSupportedException>(() => View.Clear());
+            Assert.Throws<NotSupportedException>(
+                () => View.Write(new System.IO.MemoryStream(), RdfSerializationFormat.Turtle));
+        }
+
+        #endregion
+    }
+}

--- a/Trinity.Tests/Store/LayeredModelTest.cs
+++ b/Trinity.Tests/Store/LayeredModelTest.cs
@@ -528,15 +528,30 @@ namespace Semiodesk.Trinity.Tests.Store
             Assert.Throws<NotSupportedException>(() => View.AsQueryable<MappingTestClass>(inferenceEnabled: true));
         }
 
+        /// <summary>
+        /// Writes are staged rather than refused; only the operations that cannot be routed into the
+        /// layers still throw.
+        /// </summary>
+        /// <remarks>
+        /// This test asserted the read-only surface until staging landed. A caller's SPARQL update
+        /// cannot be routed, because there is no way to tell which of its effects should become an
+        /// addition and which a removal; <c>Clear</c> is ambiguous on a view (<c>Discard</c> is the
+        /// meaningful operation); and reading into or writing out a view is a different operation from
+        /// doing so to a model. Staging behaviour itself is covered by <c>LayeredModelStagingTest</c>.
+        /// </remarks>
         [Test]
-        public virtual void WritesThrow()
+        public virtual void OnlyUnroutableOperationsThrow()
         {
-            Assert.Throws<NotSupportedException>(() => View.CreateResource(R1));
-            Assert.Throws<NotSupportedException>(() => View.CreateResource<MappingTestClass>(R1));
-            Assert.Throws<NotSupportedException>(() => View.DeleteResource(R1));
-            Assert.Throws<NotSupportedException>(() => View.UpdateResource(new MappingTestClass(R1)));
-            Assert.Throws<NotSupportedException>(() => View.ExecuteUpdate(new SparqlUpdate("CLEAR GRAPH <urn:x>")));
+            Assert.Throws<NotSupportedException>(
+                () => View.ExecuteUpdate(new SparqlUpdate($"CLEAR GRAPH <{Additions.Uri}>")));
             Assert.Throws<NotSupportedException>(() => View.Clear());
+            Assert.Throws<NotSupportedException>(
+                () => View.Write(new System.IO.MemoryStream(), RdfSerializationFormat.Turtle));
+            Assert.Throws<NotSupportedException>(
+                () => View.Read(new Uri("file:///nonexistent.ttl"), RdfSerializationFormat.Turtle, false));
+
+            // And the write paths that used to throw now stage instead.
+            Assert.DoesNotThrow(() => View.CreateResource<MappingTestClass>(R2));
         }
 
         [Test]

--- a/Trinity/Model/ILayeredModel.cs
+++ b/Trinity/Model/ILayeredModel.cs
@@ -82,5 +82,47 @@ namespace Semiodesk.Trinity
         /// <see cref="Baseline"/>.
         /// </summary>
         IModel Removals { get; }
+
+        /// <summary>
+        /// Applies the staged change to <see cref="Baseline"/> and empties both layers.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Deliberately not named <c>Commit</c>. A view owns staging, so
+        /// <see cref="Resource.Commit"/> on a resource read through one already means "stage"; reusing
+        /// the word here for "push everything to the baseline" would invite exactly the confusion the
+        /// two operations need to avoid.
+        /// </para>
+        /// <para>
+        /// Removals are applied before additions, so a triple in both survives — the same precedence
+        /// the read path gives it.
+        /// </para>
+        /// </remarks>
+        /// <param name="force">Apply even if the baseline diverged. See <see cref="HasDiverged"/>.</param>
+        /// <param name="transaction">
+        /// Transaction to run in; one is started when omitted.
+        /// </param>
+        /// <exception cref="System.InvalidOperationException">
+        /// Thrown when the baseline diverged and <paramref name="force"/> is not set.
+        /// </exception>
+        void Accept(bool force = false, ITransaction transaction = null);
+
+        /// <summary>
+        /// Abandons the staged change, leaving <see cref="Baseline"/> untouched.
+        /// </summary>
+        void Discard(ITransaction transaction = null);
+
+        /// <summary>
+        /// Indicates whether the baseline has moved on ground the staged change depends on — a triple
+        /// staged for removal that the baseline no longer holds.
+        /// </summary>
+        /// <remarks>
+        /// This matters because applying a stale change never fails on its own: a changeset is a set of
+        /// triples and <c>INSERT</c>/<c>DELETE</c> are idempotent, so a competing edit to a
+        /// single-valued property silently leaves two values behind rather than raising anything. The
+        /// check is O(removals) and deliberately conservative — it also reports the benign case where
+        /// someone else already made the same removal.
+        /// </remarks>
+        bool HasDiverged();
     }
 }

--- a/Trinity/Model/LayeredModel.cs
+++ b/Trinity/Model/LayeredModel.cs
@@ -444,8 +444,14 @@ namespace Semiodesk.Trinity
         private void Attach(Resource resource)
         {
             resource.IsNew = false;
+
+            // Capturing the snapshot: IsSynchronized's setter calls CapturePersistedValues, so the
+            // effective state as just read becomes the baseline the staged delta is computed against.
             resource.IsSynchronized = true;
-            resource.IsReadOnly = true;
+
+            // Deliberately NOT read-only. Resource.Commit() is guarded by IsReadOnly, so setting it
+            // would make a caller's Commit() a silent no-op; instead it routes into UpdateResource
+            // below and stages.
             resource.SetModel(this);
         }
 
@@ -577,92 +583,450 @@ namespace Semiodesk.Trinity
 
         #endregion
 
-        #region Not supported: the view is read-only
+        #region Staged writes
 
-        private static NotSupportedException ReadOnly()
+        /// <summary>
+        /// Stages a resource's changes into the additions and removals graphs.
+        /// </summary>
+        /// <remarks>
+        /// This is what <see cref="Resource.Commit"/> routes into for a resource read through a view,
+        /// so staging needs no separate API: committing a resource whose model is a view <i>means</i>
+        /// staging it.
+        /// </remarks>
+        public void UpdateResource(Resource resource, ITransaction transaction = null)
         {
-            return new NotSupportedException(
-                "Layered models are read-only. Stage a change by writing to the Additions and Removals " +
-                "models, which are ordinary models, and the view will read the result.");
+            UpdateResources(new[] { resource }, transaction);
         }
 
-        /// <summary>Not supported. Layered models are read-only.</summary>
-        public IResource AddResource(IResource resource, ITransaction transaction = null) => throw ReadOnly();
+        /// <inheritdoc cref="UpdateResource(Resource, ITransaction)" />
+        public void UpdateResources(IEnumerable<Resource> resources, ITransaction transaction = null)
+        {
+            var staged = new List<Resource>();
+            string update = BuildStagingUpdate(resources, staged);
 
-        /// <summary>Not supported. Layered models are read-only.</summary>
-        public T AddResource<T>(T resource, ITransaction transaction = null) where T : Resource => throw ReadOnly();
+            if (update != null)
+            {
+                _store.ExecuteNonQuery(new SparqlUpdate(update), transaction);
+            }
 
-        /// <summary>Not supported. Layered models are read-only.</summary>
-        public IResource CreateResource(string format = "urn:uuid:{0}", ITransaction transaction = null) => throw ReadOnly();
+            foreach (Resource resource in staged)
+            {
+                resource.IsNew = false;
 
-        /// <summary>Not supported. Layered models are read-only.</summary>
-        public IResource CreateResource(Uri uri, ITransaction transaction = null) => throw ReadOnly();
+                // Re-snapshot, so a second Commit stages only what changed since this one.
+                resource.IsSynchronized = true;
+            }
+        }
 
-        /// <summary>Not supported. Layered models are read-only.</summary>
-        public T CreateResource<T>(string format = "urn:uuid:{0}", ITransaction transaction = null) where T : Resource => throw ReadOnly();
-
-        /// <summary>Not supported. Layered models are read-only.</summary>
-        public T CreateResource<T>(Uri uri, ITransaction transaction = null) where T : Resource => throw ReadOnly();
-
-        /// <summary>Not supported. Layered models are read-only.</summary>
-        public object CreateResource(Type type, string format = "urn:uuid:{0}", ITransaction transaction = null) => throw ReadOnly();
-
-        /// <summary>Not supported. Layered models are read-only.</summary>
-        public object CreateResource(Uri uri, Type t, ITransaction transaction = null) => throw ReadOnly();
-
-        /// <summary>Not supported. Layered models are read-only.</summary>
-        public void DeleteResource(Uri uri, ITransaction transaction = null) => throw ReadOnly();
-
-        /// <summary>Not supported. Layered models are read-only.</summary>
-        public void DeleteResource(IResource resource, ITransaction transaction = null) => throw ReadOnly();
-
-        /// <summary>Not supported. Layered models are read-only.</summary>
-        public void DeleteResources(IEnumerable<Uri> uris, ITransaction transaction = null) => throw ReadOnly();
-
-        /// <summary>Not supported. Layered models are read-only.</summary>
-        public void DeleteResources(IEnumerable<IResource> resources, ITransaction transaction = null) => throw ReadOnly();
-
-        /// <summary>Not supported. Layered models are read-only.</summary>
-        public void DeleteResources(ITransaction transaction = null, params IResource[] resources) => throw ReadOnly();
-
-        /// <summary>Not supported. Layered models are read-only.</summary>
-        public void UpdateResource(Resource resource, ITransaction transaction = null) => throw ReadOnly();
-
-        /// <summary>Not supported. Layered models are read-only.</summary>
-        public void UpdateResources(IEnumerable<Resource> resources, ITransaction transaction = null) => throw ReadOnly();
-
-        /// <summary>Not supported. Layered models are read-only.</summary>
-        public void UpdateResources(ITransaction transaction = null, params Resource[] resources) => throw ReadOnly();
-
-        /// <summary>Not supported. Layered models are read-only.</summary>
-        public void ExecuteUpdate(ISparqlUpdate update, ITransaction transaction = null) => throw ReadOnly();
-
-        /// <summary>Not supported. Layered models are read-only.</summary>
-        public void Clear() => throw ReadOnly();
-
-        /// <summary>Not supported. Layered models are read-only.</summary>
-        public bool Read(Uri url, RdfSerializationFormat format, bool update) => throw ReadOnly();
-
-        /// <summary>Not supported. Layered models are read-only.</summary>
-        public bool Read(Stream stream, RdfSerializationFormat format, bool update) => throw ReadOnly();
-
-        /// <summary>Not supported. Layered models are read-only.</summary>
-        public bool Read(string content, RdfSerializationFormat format, bool update) => throw ReadOnly();
+        /// <inheritdoc cref="UpdateResource(Resource, ITransaction)" />
+        public void UpdateResources(ITransaction transaction = null, params Resource[] resources)
+        {
+            UpdateResources(resources, transaction);
+        }
 
         /// <summary>
-        /// Not supported. Serializing the view would mean materializing the effective graph, which
-        /// is a different operation from writing a model out; write the layer models instead.
+        /// Builds the update that stages every given resource's delta, or <c>null</c> when nothing
+        /// changed.
         /// </summary>
-        public void Write(Stream stream, RdfSerializationFormat format, INamespaceMap namespaces = null, Uri baseUri = null, bool leaveOpen = false) => throw ReadOnly();
+        /// <remarks>
+        /// <para>
+        /// Routing is conditional, and this is the crux of staging rather than a detail of it. Sending
+        /// every deleted value straight to the removals graph is wrong: stage <c>name = "new"</c>, then
+        /// change it to <c>"newer"</c>, and additions would hold both while removals held <c>"new"</c> -
+        /// and additions win, so <b>both</b> values would stay visible.
+        /// </para>
+        /// <para>
+        /// So for each value the delta reports as <b>inserted</b>: drop it from removals (which restores
+        /// it from the baseline), then add it to additions only if the baseline does not already have
+        /// it. And for each value reported as <b>deleted</b>: drop it from additions, then add it to
+        /// removals only if the baseline has it.
+        /// </para>
+        /// <para>
+        /// Those guards are also what maintain <c>additions ∩ baseline = ∅</c> and
+        /// <c>removals ⊆ baseline</c> — the invariants that keep the pre-change baseline reconstructible
+        /// as <c>(effective ∖ additions) ∪ removals</c>. See ADR-0042.
+        /// </para>
+        /// </remarks>
+        private string BuildStagingUpdate(IEnumerable<Resource> resources, List<Resource> staged)
+        {
+            if (resources == null)
+            {
+                return null;
+            }
+
+            var inserted = new List<string>();
+            var deleted = new List<string>();
+
+            foreach (Resource resource in resources)
+            {
+                if (resource == null)
+                {
+                    continue;
+                }
+
+                RequireQueryableSubject(resource.Uri);
+                staged.Add(resource);
+
+                string subject = SparqlSerializer.SerializeUri(resource.Uri);
+
+                if (SparqlSerializer.TrySerializeResourceDelta(
+                        resource, IgnoreUnmappedProperties, out var removedValues, out var addedValues))
+                {
+                    foreach (string value in addedValues) inserted.Add(subject + " " + value);
+                    foreach (string value in removedValues) deleted.Add(subject + " " + value);
+                }
+                else
+                {
+                    // No snapshot to diff against: the resource has never been synchronized, so
+                    // everything it holds is an addition.
+                    foreach (string value in SparqlSerializer.SerializeValueSet(resource, IgnoreUnmappedProperties))
+                    {
+                        inserted.Add(subject + " " + value);
+                    }
+                }
+            }
+
+            if (inserted.Count == 0 && deleted.Count == 0)
+            {
+                return null;
+            }
+
+            var operations = new List<string>();
+
+            foreach (string triple in inserted)
+            {
+                // Un-stage a removal first: if that restored the value from the baseline, the third
+                // operation then takes it back out of additions again.
+                operations.Add(Delete(Removals, triple));
+
+                // Add, then retract if the baseline already has it - rather than the more obvious
+                // "insert unless the baseline has it". Virtuoso *ignores a WHERE clause consisting
+                // only of a FILTER*, so `INSERT ... WHERE { FILTER NOT EXISTS { ... } }` inserts
+                // unconditionally there, leaving a value in additions that the baseline already holds
+                // and breaking the additions-disjoint-from-baseline invariant. Every operation here
+                // carries a real pattern instead, which all three stores evaluate correctly.
+                operations.Add(string.Format("INSERT DATA {{ GRAPH {0} {{ {1} }} }}", Graph(Additions), triple));
+                operations.Add(string.Format("DELETE {{ GRAPH {0} {{ {1} }} }} WHERE {{ GRAPH {2} {{ {1} }} }}",
+                    Graph(Additions), triple, Graph(Baseline)));
+            }
+
+            foreach (string triple in deleted)
+            {
+                operations.Add(Delete(Additions, triple));
+                operations.Add(string.Format("INSERT {{ GRAPH {0} {{ {1} }} }} WHERE {{ GRAPH {2} {{ {1} }} }}",
+                    Graph(Removals), triple, Graph(Baseline)));
+            }
+
+            return string.Join("; ", operations);
+        }
+
+        /// <summary>
+        /// A guarded delete, used in preference to <c>DELETE DATA</c> so a graph that does not yet
+        /// exist is a no-op rather than an error on stores that are strict about it.
+        /// </summary>
+        private static string Delete(IModel model, string triple)
+        {
+            return string.Format("DELETE WHERE {{ GRAPH {0} {{ {1} }} }}", Graph(model), triple);
+        }
+
+        private static string Graph(IModel model)
+        {
+            return SparqlSerializer.SerializeUri(model.Uri);
+        }
+
+        #endregion
+
+        #region Accept and discard
+
+        /// <summary>
+        /// Applies the staged change to the baseline and empties both layers.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Deliberately not called <c>Commit</c>: a view owns staging, so
+        /// <see cref="Resource.Commit"/> already means "stage", and reusing the word one level up for
+        /// "push everything to the baseline" would be a trap.
+        /// </para>
+        /// <para>
+        /// Removals are applied before additions, so a triple in both survives — the same precedence
+        /// the read path gives it.
+        /// </para>
+        /// <para>
+        /// Throws if the baseline has moved on ground the change depends on, unless
+        /// <paramref name="force"/> is set. That check matters because applying a stale changeset never
+        /// fails by itself: a changeset is a set of triples and INSERT/DELETE are idempotent, so a
+        /// competing change to a single-valued property would silently leave two values behind.
+        /// </para>
+        /// </remarks>
+        /// <param name="force">Apply even if the baseline diverged.</param>
+        /// <param name="transaction">
+        /// Transaction to run in. When omitted one is started: real on Virtuoso, a no-op elsewhere,
+        /// where a multi-operation request is atomic in its own right (measured — see ADR-0042).
+        /// </param>
+        /// <exception cref="InvalidOperationException">Thrown when the baseline diverged.</exception>
+        public void Accept(bool force = false, ITransaction transaction = null)
+        {
+            if (!force && HasDiverged())
+            {
+                throw new InvalidOperationException(
+                    "The baseline has changed since this change was staged: at least one triple staged for " +
+                    "removal is no longer present in it, so the change was computed against a state that no " +
+                    "longer holds. Applying it anyway would not fail - a changeset is a set of triples and " +
+                    "INSERT/DELETE are idempotent - it would silently merge, which for a single-valued " +
+                    "property leaves two values behind. Re-read and re-stage, or pass force to apply anyway.");
+            }
+
+            string update = string.Join("; ",
+                string.Format("DELETE {{ GRAPH {0} {{ ?s ?p ?o }} }} WHERE {{ GRAPH {1} {{ ?s ?p ?o }} }}",
+                    Graph(Baseline), Graph(Removals)),
+                string.Format("INSERT {{ GRAPH {0} {{ ?s ?p ?o }} }} WHERE {{ GRAPH {1} {{ ?s ?p ?o }} }}",
+                    Graph(Baseline), Graph(Additions)),
+                string.Format("DELETE WHERE {{ GRAPH {0} {{ ?s ?p ?o }} }}", Graph(Additions)),
+                string.Format("DELETE WHERE {{ GRAPH {0} {{ ?s ?p ?o }} }}", Graph(Removals)));
+
+            RunAtomically(update, transaction);
+        }
+
+        /// <summary>
+        /// Abandons the staged change, leaving the baseline untouched.
+        /// </summary>
+        public void Discard(ITransaction transaction = null)
+        {
+            string update = string.Join("; ",
+                string.Format("DELETE WHERE {{ GRAPH {0} {{ ?s ?p ?o }} }}", Graph(Additions)),
+                string.Format("DELETE WHERE {{ GRAPH {0} {{ ?s ?p ?o }} }}", Graph(Removals)));
+
+            RunAtomically(update, transaction);
+        }
+
+        /// <summary>
+        /// Indicates whether the baseline has moved on ground the staged change depends on: a triple
+        /// staged for removal that the baseline no longer holds.
+        /// </summary>
+        /// <remarks>
+        /// O(removals) rather than O(baseline), and deliberately conservative — it also reports the
+        /// benign case where a third party already made the same removal. A version control system
+        /// complains in the analogous situation, where the context a patch assumes no longer matches.
+        /// </remarks>
+        public bool HasDiverged()
+        {
+            ISparqlQuery query = CreateOverlayQuery(string.Format(
+                "ASK {0}{{ GRAPH {1} {{ ?s ?p ?o }} FILTER NOT EXISTS {{ GRAPH {2} {{ ?s ?p ?o }} }} }}",
+                _datasetClause, Graph(Removals), Graph(Baseline)));
+
+            return ExecuteOverlayQuery(query, null).GetAnwser();
+        }
+
+        /// <summary>
+        /// Runs a multi-operation update, in a real transaction where the store has one.
+        /// </summary>
+        private void RunAtomically(string update, ITransaction transaction)
+        {
+            if (transaction != null)
+            {
+                _store.ExecuteNonQuery(new SparqlUpdate(update), transaction);
+
+                return;
+            }
+
+            ITransaction own = _store.BeginTransaction(IsolationLevel.ReadCommitted);
+
+            try
+            {
+                _store.ExecuteNonQuery(new SparqlUpdate(update), own);
+                own.Commit();
+            }
+            catch
+            {
+                own.Rollback();
+
+                throw;
+            }
+        }
+
+        #endregion
+
+        #region Creating and deleting resources
+
+        /// <inheritdoc cref="UpdateResource(Resource, ITransaction)" />
+        public IResource AddResource(IResource resource, ITransaction transaction = null)
+        {
+            return AddResource<Resource>((Resource)resource, transaction);
+        }
+
+        /// <inheritdoc cref="UpdateResource(Resource, ITransaction)" />
+        public T AddResource<T>(T resource, ITransaction transaction = null) where T : Resource
+        {
+            T staged = CreateResource<T>(resource.Uri, transaction);
+
+            foreach (var value in resource.ListValues())
+            {
+                staged.AddPropertyToMapping(value.Item1, value.Item2, true);
+            }
+
+            staged.Commit();
+
+            return staged;
+        }
+
+        /// <summary>Creates a resource whose triples will be staged as additions when committed.</summary>
+        public IResource CreateResource(string format = "urn:uuid:{0}", ITransaction transaction = null)
+        {
+            return CreateResource<Resource>(format, transaction);
+        }
+
+        /// <inheritdoc cref="CreateResource(string, ITransaction)" />
+        public IResource CreateResource(Uri uri, ITransaction transaction = null)
+        {
+            return CreateResource<Resource>(uri, transaction);
+        }
+
+        /// <inheritdoc cref="CreateResource(string, ITransaction)" />
+        public T CreateResource<T>(string format = "urn:uuid:{0}", ITransaction transaction = null) where T : Resource
+        {
+            return CreateResource<T>(UriRef.GetGuid(format), transaction);
+        }
+
+        /// <inheritdoc cref="CreateResource(string, ITransaction)" />
+        public T CreateResource<T>(Uri uri, ITransaction transaction = null) where T : Resource
+        {
+            return (T)CreateResource(uri, typeof(T), transaction);
+        }
+
+        /// <inheritdoc cref="CreateResource(string, ITransaction)" />
+        public object CreateResource(Type type, string format = "urn:uuid:{0}", ITransaction transaction = null)
+        {
+            return CreateResource(UriRef.GetGuid(format), type, transaction);
+        }
+
+        /// <inheritdoc cref="CreateResource(string, ITransaction)" />
+        public object CreateResource(Uri uri, Type type, ITransaction transaction = null)
+        {
+            RequireQueryableSubject(uri);
+
+            if (!typeof(Resource).IsAssignableFrom(type))
+            {
+                throw new ArgumentException($"The given type {type} does not derive from Resource.");
+            }
+
+            var resource = (Resource)Activator.CreateInstance(type, uri);
+
+            resource.IsNew = true;
+            resource.SetModel(this);
+
+            return resource;
+        }
+
+        /// <summary>
+        /// Stages the removal of every triple the view shows for this resource.
+        /// </summary>
+        /// <remarks>
+        /// Broad by design, as elsewhere in Trinity (ADR-0030): triples where the resource is the
+        /// object are staged for removal too, so a deleted resource leaves no dangling references
+        /// through the view.
+        /// </remarks>
+        public void DeleteResource(Uri uri, ITransaction transaction = null)
+        {
+            RequireQueryableSubject(uri);
+
+            string subject = SparqlSerializer.SerializeUri(uri);
+            string touches = string.Format("?s ?p ?o . FILTER (?s = {0} || ?o = {0})", subject);
+
+            string update = string.Join("; ",
+                // Anything the baseline holds for it becomes a staged removal...
+                string.Format("INSERT {{ GRAPH {0} {{ ?s ?p ?o }} }} WHERE {{ GRAPH {1} {{ {2} }} }}",
+                    Graph(Removals), Graph(Baseline), touches),
+                // ...and anything only staged as an addition is simply un-staged.
+                string.Format("DELETE {{ GRAPH {0} {{ ?s ?p ?o }} }} WHERE {{ GRAPH {0} {{ {1} }} }}",
+                    Graph(Additions), touches));
+
+            RunAtomically(update, transaction);
+        }
+
+        /// <inheritdoc cref="DeleteResource(Uri, ITransaction)" />
+        public void DeleteResource(IResource resource, ITransaction transaction = null)
+        {
+            DeleteResource(resource.Uri, transaction);
+        }
+
+        /// <inheritdoc cref="DeleteResource(Uri, ITransaction)" />
+        public void DeleteResources(IEnumerable<Uri> uris, ITransaction transaction = null)
+        {
+            foreach (Uri uri in uris)
+            {
+                DeleteResource(uri, transaction);
+            }
+        }
+
+        /// <inheritdoc cref="DeleteResource(Uri, ITransaction)" />
+        public void DeleteResources(IEnumerable<IResource> resources, ITransaction transaction = null)
+        {
+            DeleteResources(resources.Select(r => (Uri)r.Uri), transaction);
+        }
+
+        /// <inheritdoc cref="DeleteResource(Uri, ITransaction)" />
+        public void DeleteResources(ITransaction transaction = null, params IResource[] resources)
+        {
+            DeleteResources(resources, transaction);
+        }
+
+        /// <summary>
+        /// Begins a transaction on the underlying store.
+        /// </summary>
+        /// <remarks>
+        /// Real only where the store provides one — Virtuoso does; the others hand back a
+        /// <c>NoOpTransaction</c> whose rollback provably undoes nothing (ADR-0028), and rely instead
+        /// on a multi-operation request being atomic in its own right.
+        /// </remarks>
+        public ITransaction BeginTransaction(IsolationLevel isolationLevel)
+        {
+            return _store.BeginTransaction(isolationLevel);
+        }
+
+        #endregion
+
+        #region Not supported
+
+        private static NotSupportedException Unsupported(string what)
+        {
+            return new NotSupportedException(
+                "A layered model cannot " + what + ". Stage changes by modifying resources read through " +
+                "the view and committing them, then Accept() or Discard() the result; or address the " +
+                "Baseline, Additions and Removals models directly, which are ordinary models.");
+        }
+
+        /// <summary>
+        /// Not supported: a caller's update cannot be routed into the layers the way a resource delta
+        /// can, because there is no way to tell which of its effects should become an addition and
+        /// which a removal.
+        /// </summary>
+        public void ExecuteUpdate(ISparqlUpdate update, ITransaction transaction = null) =>
+            throw Unsupported("run a caller-supplied SPARQL update");
+
+        /// <summary>
+        /// Not supported: ambiguous on a view. Use <see cref="Discard"/> to drop the staged change, or
+        /// clear the layer models individually.
+        /// </summary>
+        public void Clear() => throw Unsupported("be cleared");
+
+        /// <summary>Not supported. Read into the Additions or Baseline model instead.</summary>
+        public bool Read(Uri url, RdfSerializationFormat format, bool update) => throw Unsupported("be read into");
+
+        /// <inheritdoc cref="Read(Uri, RdfSerializationFormat, bool)" />
+        public bool Read(Stream stream, RdfSerializationFormat format, bool update) => throw Unsupported("be read into");
+
+        /// <inheritdoc cref="Read(Uri, RdfSerializationFormat, bool)" />
+        public bool Read(string content, RdfSerializationFormat format, bool update) => throw Unsupported("be read into");
+
+        /// <summary>
+        /// Not supported: serializing the view would mean materializing the effective graph, which is a
+        /// different operation from writing a model out.
+        /// </summary>
+        public void Write(Stream stream, RdfSerializationFormat format, INamespaceMap namespaces = null, Uri baseUri = null, bool leaveOpen = false) =>
+            throw Unsupported("be written out");
 
         /// <inheritdoc cref="Write(Stream, RdfSerializationFormat, INamespaceMap, Uri, bool)" />
-        public void Write(Stream stream, IRdfWriter formatWriter, bool leaveOpen = false) => throw ReadOnly();
-
-        /// <summary>
-        /// Not supported. A layered view spans three graphs and never writes, so there is nothing
-        /// for a transaction to scope.
-        /// </summary>
-        public ITransaction BeginTransaction(IsolationLevel isolationLevel) => throw ReadOnly();
+        public void Write(Stream stream, IRdfWriter formatWriter, bool leaveOpen = false) => throw Unsupported("be written out");
 
         #endregion
     }

--- a/Trinity/Query/SparqlSerializer.cs
+++ b/Trinity/Query/SparqlSerializer.cs
@@ -255,7 +255,15 @@ namespace Semiodesk.Trinity
             return true;
         }
 
-        private static HashSet<string> SerializeValueSet(IResource resource, bool ignoreUnmappedProperties)
+        /// <summary>
+        /// The resource's values as <c>predicate object</c> fragments.
+        /// </summary>
+        /// <remarks>
+        /// Internal rather than private because a layered model stages a resource that has no snapshot
+        /// yet - a newly created one - by treating every value it holds as an addition, which needs the
+        /// same fragments the delta writer compares.
+        /// </remarks>
+        internal static HashSet<string> SerializeValueSet(IResource resource, bool ignoreUnmappedProperties)
         {
             var result = new HashSet<string>(StringComparer.Ordinal);
 

--- a/doc/adr/0042-staged-writes-and-accept.md
+++ b/doc/adr/0042-staged-writes-and-accept.md
@@ -3,11 +3,13 @@
 Date: 2026-08-20
 
 ## Status
-Proposed
+Accepted for staging, accept and discard. **Proposed** for materialization and for anything that needs a
+retained ancestor.
 
-Recorded because the reasoning below was expensive to arrive at and is easy to lose, not because the
-shape is settled. Several details are open — see *Deliberately unresolved* — and some of them touch
-parts of the system that have not been decided either.
+The staging half is built and measured: `Commit()` through a view stages, `Accept()`/`Discard()` apply
+or abandon, and the divergence precondition is in place, all verified on the in-memory store, Virtuoso
+and GraphDB. Materialization, three-way merge and changeset validation remain proposals — see
+*Deliberately unresolved*.
 
 ## Context
 
@@ -80,9 +82,24 @@ CLEAR GRAPH <additions>; CLEAR GRAPH <removals>
 path gives it. Worth stating as an invariant: additions win in both directions. Discard is the two
 `CLEAR`s alone.
 
-**Accept is not atomic on most backends.** Only Virtuoso has real transactions (ADR-0028); the others
-return `NoOpTransaction`, so a failure part-way leaves the baseline half-changed and the layers
-partly cleared.
+**Accept is atomic on all three backends, by two different mechanisms — measured.** The original
+assumption here was that it could not be, and that was wrong:
+
+| store | a multi-operation request | an explicit transaction |
+|---|---|---|
+| dotNetRDF in-memory | **atomic** — injecting a failure into the second operation rolls the first back | `NoOpTransaction`; rollback provably undoes nothing |
+| Virtuoso | unprobed — it silently succeeds on every failure that could be injected | **`VirtuosoTransaction`** — rollback *and* commit both honoured |
+| GraphDB | **atomic** — same rollback observed | `NoOpTransaction`; rollback provably undoes nothing |
+
+So `Accept()` starts a transaction unconditionally: real on Virtuoso, a no-op elsewhere where request
+atomicity already covers it. Note the corollary for the other two stores — passing a transaction there
+would give a false sense of safety, since rollback demonstrably does nothing; it is request atomicity
+that protects the operation.
+
+Worth recording separately: **Virtuoso swallows failures other stores raise.** `CLEAR` and `DROP` of an
+absent graph, `CREATE` of an existing one, and `LOAD` of an unresolvable URL all succeed silently there,
+several of which the specification makes errors absent `SILENT`. A failed `LOAD` cannot be detected on
+Virtuoso at all.
 
 ### It is a working copy, not a branch
 
@@ -225,7 +242,12 @@ documented limitation and a trap.
 ## Consequences
 
 - `resource.Commit()` works through a view with no caller change, which is what 0041 promised for reads
-  and did not deliver for writes.
+  and did not deliver for writes. It was previously a **silent no-op**, because `Attach` marked the
+  resource read-only and `Commit()` is guarded by that flag.
+- A forced accept produces a schema violation that the **mapped read layer hides**: two values land in
+  the baseline for a single-valued property, and a `PropertyMapping<T>` read collapses them to one. The
+  data is wrong where a caller would not think to look, which is the sharpest argument for the
+  precondition refusing by default.
 - Four separate problems — staleness detection, deleted-value routing, ancestor recoverability, and
   incremental maintenance — are all solved by the same decision, which is the strongest argument that it
   is the right one.
@@ -244,10 +266,8 @@ Recorded so these are not mistaken for oversights:
 - **Validation of changesets.** Whether SHACL runs over a narrow graph derived from the changeset, what
   its extent must be, and how much of a shapes graph the mapping can generate. Deliberately excluded
   here; it touches parts of the system that are themselves unsettled.
-- **Reconstruct the ancestor or freeze it.** Both are described above; the choice depends on whether the
-  staging invariant is enforced strictly enough to be relied on.
-- **Atomicity of accept** on the non-transactional stores. Possibly a compensating log, possibly a
-  documented exposure.
+- **Reconstruct the ancestor or freeze it.** Both are described above. The staging invariants are now
+  maintained by construction and asserted by tests, so reconstruction is viable; the choice remains.
 - **Additions-side conflict detection**, which needs the mapping-derived cardinality described above.
 - **Concurrent accepts** from two views over one baseline. That is branching, and needs a retained
   per-view ancestor.

--- a/doc/adr/README.md
+++ b/doc/adr/README.md
@@ -86,7 +86,7 @@ mapped/dynamic duality, models & groups, discovery, stores, and querying.
 | # | Title | Status |
 |---|-------|--------|
 | [0015](0015-modernize-target-frameworks-and-ci.md) | Modernize target frameworks, build, and CI | Proposed |
-| [0042](0042-staged-writes-and-accept.md) | Staged writes: the layered view as a working copy (accept/discard, materialization, conflicts) | Proposed |
+| [0042](0042-staged-writes-and-accept.md) | Staged writes: the layered view as a working copy (accept/discard, materialization, conflicts) | Accepted (staging) / Proposed (rest) |
 
 ## Revival north star
 

--- a/tests/Trinity.Tests.GraphDB/GraphDBLayeredModelStagingTest.cs
+++ b/tests/Trinity.Tests.GraphDB/GraphDBLayeredModelStagingTest.cs
@@ -1,0 +1,38 @@
+// LICENSE:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// AUTHORS:
+//
+//  Moritz Eberl <moritz@semiodesk.com>
+//  Sebastian Faubel <sebastian@semiodesk.com>
+//
+// Copyright (c) Semiodesk GmbH 2026
+
+using NUnit.Framework;
+using Semiodesk.Trinity.Tests.Store;
+
+namespace Semiodesk.Trinity.Tests.GraphDB
+{
+    /// <summary>
+    /// Runs the staged-writes suite against GraphDB.
+    /// </summary>
+    [TestFixture]
+    public class GraphDBLayeredModelStagingTest : LayeredModelStagingTest<GraphDBTestSetup> { }
+}

--- a/tests/Trinity.Tests.Virtuoso/VirtuosoLayeredModelStagingTest.cs
+++ b/tests/Trinity.Tests.Virtuoso/VirtuosoLayeredModelStagingTest.cs
@@ -1,0 +1,38 @@
+// LICENSE:
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// AUTHORS:
+//
+//  Moritz Eberl <moritz@semiodesk.com>
+//  Sebastian Faubel <sebastian@semiodesk.com>
+//
+// Copyright (c) Semiodesk GmbH 2026
+
+using NUnit.Framework;
+using Semiodesk.Trinity.Tests.Store;
+
+namespace Semiodesk.Trinity.Tests.Virtuoso
+{
+    /// <summary>
+    /// Runs the staged-writes suite against Virtuoso.
+    /// </summary>
+    [TestFixture]
+    public class VirtuosoLayeredModelStagingTest : LayeredModelStagingTest<VirtuosoTestSetup> { }
+}


### PR DESCRIPTION
## What

Follows #37. Turns the read-only layered view into a **working copy**: `Commit()` stages, `Accept()` applies, `Discard()` abandons.

```csharp
var view = store.CreateLayeredModel(baseline, additions, removals);

var person = view.GetResource<Person>(uri);
person.Name = "changed";
person.Commit();          // stages into additions/removals — the baseline is untouched

view.Accept();            // applies to the baseline, empties both layers
// or view.Discard();     // abandons, baseline never touched
```

**No new API for staging.** `Resource.Commit()` already routes through `_model.UpdateResource`, so implementing that on `LayeredModel` makes committing a resource whose model is a view *mean* staging it. That's what #37 promised for reads and didn't deliver for writes — and until now it was a **silent no-op**, because `Attach()` marked the resource read-only and `Commit()` is guarded by that flag.

Staging reuses `SparqlSerializer.TrySerializeResourceDelta`, the store-independent delta all four write paths already share (ADR-0039). So this is one update builder and **zero per-store work** — correcting ADR-0041's claim that a writable view needs a new write path in every store.

## The crux: routing deleted values

Sending every deleted value to the removals graph looks obviously right and is silently wrong:

1. Stage `name = "new"` → additions gains `"new"`
2. Change to `"newer"` → the delta reports `"new"` deleted, `"newer"` inserted
3. Put `"new"` in removals → additions holds **both**, removals holds `"new"` — and **additions win**, so both values stay visible

So routing is conditional: an inserted value is first un-staged from removals and only added to additions if the baseline doesn't already hold it; a deleted value is first un-staged from additions and only added to removals if the baseline does. Those guards also maintain `additions ∩ baseline = ∅` and `removals ⊆ baseline` — the invariants that keep the pre-change baseline reconstructible as `(effective ∖ additions) ∪ removals`, and therefore keep three-way merge possible later. Both are asserted by tests.

## Conflicts: refuse by default

`Accept()` applies removals **before** additions, so a triple staged in both survives — the same precedence reads give it.

It refuses when the baseline has moved on ground the change depends on (any triple staged for removal the baseline no longer holds). That matters because applying a stale changeset **never fails on its own**: a changeset is a set of triples and `INSERT`/`DELETE` are idempotent, so it silently merges. The check is `O(removals)`, sound, and deliberately conservative — it also flags the benign case where someone else already made the same removal. `Accept(force: true)` applies anyway.

> **The sharpest argument for refusing:** a forced accept leaves two values in the baseline for a single-valued property — and because it's a `PropertyMapping<string>`, a **mapped read collapses them to one**. The violation is real in the data and invisible through the API a caller would use to look for it. My first version of that test asserted through the mapped property and passed for the wrong reason.

Still refused: a caller-supplied SPARQL update (no way to tell which effects should become additions vs removals), `Clear()` (ambiguous on a view — `Discard()` is the meaningful operation), and reading into / writing out a view.

## Two store behaviours, both measured

**Accept is atomic on all three backends** — ADR-0042 originally assumed it couldn't be, and that was wrong:

| store | multi-operation request | explicit transaction |
|---|---|---|
| dotNetRDF in-memory | **atomic** — a failure in op 2 rolls back op 1 | `NoOpTransaction`; rollback provably does nothing |
| Virtuoso | unprobed — it silently succeeds on every failure injectable | **`VirtuosoTransaction`** — rollback *and* commit honoured |
| GraphDB | **atomic** — same rollback observed | `NoOpTransaction`; rollback provably does nothing |

`Accept()` therefore starts a transaction unconditionally: real on Virtuoso, a no-op elsewhere where request atomicity already covers it. Corollary worth knowing — on the other two, *passing* a transaction gives a false sense of safety.

**Virtuoso ignores a `WHERE` clause consisting only of a `FILTER`.** So the obvious guard —

```sparql
INSERT { GRAPH <additions> { T } } WHERE { FILTER NOT EXISTS { GRAPH <baseline> { T } } }
```

— inserts *unconditionally* there, leaving a value in additions the baseline already holds and breaking the disjointness invariant. Verified in isolation; the same guard with a real pattern in the `WHERE` evaluates correctly. The implementation now adds then retracts, so every operation carries a real pattern.

**This was caught by the cross-store suite, failing on Virtuoso alone.** Had the tests been in-memory only, it would have shipped.

Also recorded: Virtuoso silently succeeds on `CLEAR`/`DROP` of an absent graph, `CREATE` of an existing one, and `LOAD` of an unresolvable URL — so a failed `LOAD` cannot be detected there at all.

## Tests

13 cases per backend on the shared cross-store fixture, since staging and accept are both multi-operation updates and that's exactly where the three stores have diverged throughout this work.

| suite | before | now | pre-existing failures |
|---|---|---|---|
| in-memory | 589 | **602** / 7 skipped | 3, unchanged |
| Virtuoso | 221 | **234** / 1 skipped | 4 inferencing, unchanged |
| GraphDB | 228 | **241** / 1 skipped | 4 inferencing, unchanged |
| Generator / Vocabulary | 23 / 29 | 23 / 29 | none |

Exactly +13 per backend. Store suites need Docker and are excluded from the default CI job (ADR-0036), so CI will show only the in-memory run; all three were run locally against merged `develop`.

⚠️ Pre-existing failures a reviewer will see, all reproducing on `develop`: in-memory `Equal` / `ResourceConstructorTest` / `EqualsTest` (an artefact of `DOTNET_ROLL_FORWARD` on .NET 10 with no net8.0 runtime installed), and the 4 inferencing tests per store — consistent with this design refusing inferencing.

Two existing guards were reclassified, both of which encoded the read-only surface and both of which failed exactly as intended when it changed: `WritesThrow` → `OnlyUnroutableOperationsThrow`, and the reflection-driven `EveryModelMemberIsEitherHonouredOrThrows` moves the write members from refused to honoured. That guard exists to force the decision explicitly rather than by omission, and it did.

## Docs

ADR-0042's status splits: **Accepted** for staging/accept/discard, still **Proposed** for materialization and anything needing a retained ancestor. The two predictions it got wrong are corrected with measurements rather than quietly edited.

## Review guide

Three commits, each building: `fad919a` implementation, `9b2f6d7` tests, `707fbb3` docs. Start with `doc/adr/0042-staged-writes-and-accept.md`; the routing rule in `LayeredModel.BuildStagingUpdate` is the part most worth a careful read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
