### PR TITLE
Remove the dead IModelGroup.DefaultModel

### DIFF
--- a/Trinity/Model/IModelGroup.cs
+++ b/Trinity/Model/IModelGroup.cs
@@ -39,9 +39,8 @@ namespace Semiodesk.Trinity
         ICollection<IModel>
     #endif
     {
-        /// <summary>
-        /// The default model of this group
-        /// </summary>
-        IModel DefaultModel { get; set;  }
+        // Nothing beyond IModel and ISet<IModel>. This interface exists to name the combination -
+        // a set of models that is itself a model - not to add behaviour to it. It previously also
+        // declared a DefaultModel property that nothing ever read or assigned; see ADR-0019.
     }
 }

--- a/Trinity/Model/ModelGroup.cs
+++ b/Trinity/Model/ModelGroup.cs
@@ -75,11 +75,6 @@ namespace Semiodesk.Trinity
         }
 
         /// <summary>
-        /// The default model of this group.
-        /// </summary>
-        public IModel DefaultModel { get; set; }
-
-        /// <summary>
         /// Uri of the model group is null.
         /// </summary>
         public UriRef Uri { get { return null; } }

--- a/doc/adr/0019-models-are-named-graphs-modelgroups.md
+++ b/doc/adr/0019-models-are-named-graphs-modelgroups.md
@@ -32,9 +32,12 @@ See `Trinity/Model/Model.cs`, `Trinity/Model/IModelGroup.cs`, `Trinity/Model/Mod
   inverse of that. Subtracting a graph needs the guard inside the graph pattern, which is a different
   abstraction — see [0041](0041-layered-read-views.md), which adds `ILayeredModel` as a sibling rather
   than extending this one.
-- `IModelGroup.DefaultModel` is **dead**: declared on the interface, auto-implemented on `ModelGroup`,
-  and never read or assigned anywhere in the repository. It records an intent that was never wired up.
-  Removing it is a breaking change to a public interface and has been left for its own change.
+- `IModelGroup.DefaultModel` was **removed**. It was declared on the interface, auto-implemented on
+  `ModelGroup`, and never read or assigned anywhere in the repository — an intent that was never wired
+  up. A caller could set it and nothing would happen, which is worse than the property not existing.
+  Removing it is a breaking change to a public interface, taken deliberately in 2.0.
+  `IModelGroup` now adds nothing to `IModel` ∪ `ISet<IModel>`: it exists to name the combination — a set
+  of models that is itself a model — rather than to add behaviour to it.
 
 ## Related
 - [0008](0008-store-model-abstraction.md), [0009](0009-supported-store-backends.md),


### PR DESCRIPTION
## What

Removes `IModelGroup.DefaultModel`. Three files, +9/−12.

It was declared on the interface, auto-implemented on `ModelGroup`, and **never read or assigned anywhere in the repository** — no store, no test, no call site. A caller could set it and nothing whatsoever would happen, which is worse than the property not existing: it reads as a supported way to give a group a default model, and silently isn't one.

## Why now

Found while building layered read views (#37), where the question of whether it was a foundation for making a model group writable had to be answered. It wasn't — it records an intent that was never wired up. ADR-0019 recorded that and deferred the removal to its own change; this is that change.

Breaking, deliberately. 2.0 is already a breaking release, and this is the moment to drop a no-op member rather than carry it into a published API.

## One thing worth a comment rather than a puzzled reader

`IModelGroup` now adds nothing to `IModel` ∪ `ISet<IModel>`. That's not an accident and shouldn't look like one, so the interface carries a note: it exists to *name* the combination — a set of models that is itself a model — rather than to add behaviour to it.

## Verified

| suite | this branch | develop | 
|---|---|---|
| in-memory | 589 passed / 3 failed / 7 skipped | identical |
| Virtuoso | 221 passed / 4 failed / 1 skipped | identical |
| Generator | 23 passed | identical |

Whole solution builds — nothing referenced the member. The pre-existing failures (in-memory `Equal` / `ResourceConstructorTest` / `EqualsTest`, and the 4 inferencing tests per store) all reproduce on `develop`.

Independent of #38, which stacks on the same `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
