### PR TITLE
docs: record that new files name only the active author

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,8 +242,10 @@ Invariants that surprise newcomers:
 
 ## Conventions
 
-- Every `.cs` starts with the MIT license header block (authors Moritz Eberl / Sebastian
-  Faubel, Copyright Semiodesk GmbH). Preserve it on new files.
+- Every `.cs` starts with the MIT license header block (Copyright Semiodesk GmbH). Preserve it on new
+  files. **New files name only Moritz Eberl** in the `AUTHORS` block — Sebastian Faubel no longer
+  contributes. Existing files keep both names; the attribution was accurate when they were written, so
+  there is nothing to correct.
 - 4-space indent, Allman braces, XML-doc comments on public members. No `.editorconfig` yet.
 - Nullable/ImplicitUsings are **not** enabled repo-wide (a deliberate later pass).
 


### PR DESCRIPTION
Sebastian Faubel no longer contributes to the project, so the header convention in `CLAUDE.md` is updated: files added from here on name only Moritz Eberl in the `AUTHORS` block.

Existing files are deliberately untouched — the attribution was accurate when they were written, so there is nothing to correct. If you'd rather the ~23 new files from the layered-model work be retrofitted too, that's a one-line deletion per file and can follow as its own PR.

`#40` already applies the new form to the four files it introduces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)